### PR TITLE
get rid of ember-cli-qunit dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
     - $HOME/.npm
 
 env:
-  - TEST_FRAMEWORK=ember-cli-qunit
+  - TEST_FRAMEWORK=ember-qunit
   - TEST_FRAMEWORK=ember-cli-mocha
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Code Climate](https://codeclimate.com/github/trentmwillis/ember-exam/badges/gpa.svg)](https://codeclimate.com/github/trentmwillis/ember-exam)
 [![Node Test Coverage](https://codeclimate.com/github/trentmwillis/ember-exam/badges/coverage.svg)](https://codeclimate.com/github/trentmwillis/ember-exam/coverage)
 
-Ember Exam is an addon to allow you more control over how you run your tests when used in conjunction with [Ember CLI QUnit](https://github.com/ember-cli/ember-cli-qunit) or [Ember CLI Mocha](https://github.com/ember-cli/ember-cli-mocha). It provides the ability to randomize, split, and parallelize your test suite by adding a more robust CLI command.
+Ember Exam is an addon to allow you more control over how you run your tests when used in conjunction with [Ember QUnit](https://github.com/emberjs/ember-qunit) or [Ember CLI Mocha](https://github.com/ember-cli/ember-cli-mocha). It provides the ability to randomize, split, and parallelize your test suite by adding a more robust CLI command.
 
 It started as a way to help reduce flaky tests and encourage healthy test driven development. It's like [Head & Shoulders](http://www.headandshoulders.com/) for your tests!
 
@@ -41,11 +41,11 @@ import loadEmberExam from 'ember-exam/test-support/load';
 loadEmberExam();
 ```
 
-If you are using `ember-cli-qunit@>=4`, you need to call `loadEmberExam` before the call to `start`.
+If you are using `ember-qunit@>=3`, you need to call `loadEmberExam` before the call to `start`.
 
 ### Version `>=0.7.0`
 
-Starting with version `0.7.0`, Ember Exam must be loaded explicitly by calling `loadEmberExam`. Prior to this release, Ember Exam would load its functionality automatically when the document loaded. This change was made to remove some "magic" from the system and takes a cue from the [changes in `ember-cli-qunit@4`](https://github.com/ember-cli/ember-cli-qunit#upgrading). For more details on how to load Ember Exam, see the _How To Use_ section above.
+Starting with version `0.7.0`, Ember Exam must be loaded explicitly by calling `loadEmberExam`. Prior to this release, Ember Exam would load its functionality automatically when the document loaded. This change was made to remove some "magic" from the system and takes a cue from the [changes in `ember-qunit@3`](https://github.com/emberjs/ember-qunit#upgrading). For more details on how to load Ember Exam, see the _How To Use_ section above.
 
 ### Randomization
 

--- a/bin/install-test-framework.sh
+++ b/bin/install-test-framework.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
 if [ "${TEST_FRAMEWORK}" = "ember-cli-mocha" ]; then
-  npm uninstall --save-dev ember-cli-qunit
+  npm uninstall --save-dev ember-qunit
   echo "n" | ember install ember-cli-mocha@0.14.4
 fi

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-qunit": "^4.0.0",
+    "ember-qunit": "^4.1.1",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -19,7 +19,5 @@ loadEmberExam();
 if (framework === 'qunit') {
   // Use string literal to prevent Babel to transpile this into ES6 import
   // that would break when tests run with Mocha framework.
-  // In ember-qunit 3.4.0, this new check was added: https://github.com/emberjs/ember-qunit/commit/a7e93c4b4b535dae62fed992b46c00b62bfc83f4
-	// which adds this Ember.onerror validation test. As this is a test suite for the tests, it's not needed to run ember.OnerrorValidation tests.
-  require(`ember-${framework}`).start({ setupEmberOnerrorValidation: false });
+  require(`ember-${framework}`).start();
 }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -15,9 +15,11 @@ Object.keys(require.entries).forEach((entry) => {
 require(`ember-${framework}`).default.setResolver(resolver);
 loadEmberExam();
 
-// ember-cli-qunit >= v4 support
+// ember-qunit >= v3 support
 if (framework === 'qunit') {
   // Use string literal to prevent Babel to transpile this into ES6 import
   // that would break when tests run with Mocha framework.
-  require(`ember-cli-${framework}`).start();
+  // In ember-qunit 3.4.0, this new check was added: https://github.com/emberjs/ember-qunit/commit/a7e93c4b4b535dae62fed992b46c00b62bfc83f4
+	// which adds this Ember.onerror validation test. As this is a test suite for the tests, it's not needed to run ember.OnerrorValidation tests.
+  require(`ember-${framework}`).start({ setupEmberOnerrorValidation: false });
 }


### PR DESCRIPTION
This pr contains three changes:
1. Removing dependency in ember-cli-qunit - ember-cli-qunit is getting deprecated and Ember Exam's using ember-cli-qunit to invoke ember-qunit as a wrapper.
2. Disable sandbox when running Chrome inside a container in testem.js
3. Pass { setupEmberOnerrorValidation: false } param to disable running Ember.onerror validation test in ember-exam