### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "rimraf": "^2.6.2"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
     "codeclimate-test-reporter": "^0.5.0",
     "ember-cli": "~2.15.1",
     "ember-cli-dependency-checker": "^3.0.0",
@@ -42,8 +41,6 @@
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-qunit": "^4.1.1",
     "ember-cli-shims": "^1.1.0",
-    "ember-cli-sri": "^2.1.0",
-    "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",


### PR DESCRIPTION
... because we don't use them for the dummy app