### PR TITLE
tests: Import `setResolver()` from `@ember/test-helpers`

### DIFF
--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,5 +1,6 @@
 /* globals require */
 
+import { setResolver } from '@ember/test-helpers';
 import resolver from './helpers/resolver';
 import loadEmberExam from 'ember-exam/test-support/load';
 
@@ -12,7 +13,8 @@ Object.keys(require.entries).forEach((entry) => {
   }
 });
 
-require(`ember-${framework}`).default.setResolver(resolver);
+setResolver(resolver);
+
 loadEmberExam();
 
 // ember-qunit >= v3 support


### PR DESCRIPTION
`setResolver()` was deprecated for quite some time and finally removed from `ember-qunit` in v4.2.0

This fixes the "floating dependencies" scenario on TravisCI