### PR TITLE
Run test:all to trigger ember & node test in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ jobs:
         - ./bin/install-test-framework.sh
       script:
         - yarn lint:js
-        - yarn test
+        - yarn test:all
 
     - name: "Floating Dependencies"
       script:
-        - yarn test
+        - yarn test:all
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -13,7 +13,7 @@ function getNumberOfTests(str) {
   return match && parseInt(match[1], 10);
 }
 
-const TOTAL_NUM_TESTS = 56; // Total Number of tests without the global "Ember.onerror validation tests"
+const TOTAL_NUM_TESTS = 33; // Total Number of tests without the global "Ember.onerror validation tests"
 
 function getTotalNumberOfTests(output) {
   // In ember-qunit 3.4.0, this new check was added: https://github.com/emberjs/ember-qunit/commit/a7e93c4b4b535dae62fed992b46c00b62bfc83f4

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -146,8 +146,8 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        'tests/index.html?hidepassed&derp=herp&_split=2&_partition=1',
-        'tests/index.html?hidepassed&derp=herp&_split=2&_partition=2'
+        'tests/index.html?hidepassed&_split=2&_partition=1',
+        'tests/index.html?hidepassed&_split=2&_partition=2'
       ]);
     });
 
@@ -159,8 +159,8 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        'tests/index.html?hidepassed&derp=herp&_split=4&_partition=3',
-        'tests/index.html?hidepassed&derp=herp&_split=4&_partition=4'
+        'tests/index.html?hidepassed&_split=4&_partition=3',
+        'tests/index.html?hidepassed&_split=4&_partition=4'
       ]);
     });
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "ember build",
     "test": "ember test",
     "test:all": "ember try:each && yarn test:node",
-    "test:node": "nyc mocha 'node-tests/**/*-test.js",
+    "test:node": "nyc mocha 'node-tests/**/*-test.js'",
     "coverage": "nyc report --reporter=text-lcov | codeclimate-test-reporter"
   },
   "dependencies": {


### PR DESCRIPTION
Previous .travis.yml runs `yarn test` which triggers `ember test`. Running `yarn test:all` allows executing both `ember test` and `node test`. 