### PR TITLE
[WIP] newly proposed commands

### DIFF
--- a/addon-test-support/-private/ember-exam-qunit-test-loader.js
+++ b/addon-test-support/-private/ember-exam-qunit-test-loader.js
@@ -52,12 +52,12 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
    * Loads the test modules depending on the urlParam
    */
   loadModules() {
-    const loadBalance = this._urlParams.get('loadBalance');
+    // if url params has browser key it's defaulting to load tests balance
     const browserId = this._urlParams.get('browser');
     let partitions = this._urlParams.get('partition');
-    let split = parseInt(this._urlParams.get('split'), 10);
+    let partitionCount = parseInt(this._urlParams.get('partitionCount'), 10);
 
-    split = isNaN(split) ? 1 : split;
+    partitionCount = isNaN(partitionCount) ? 1 : partitionCount;
 
     if (partitions === undefined) {
       partitions = [1];
@@ -67,11 +67,11 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
 
     super.loadModules();
 
-    if (loadBalance && this._testem) {
+    if (browserId && this._testem) {
       this.setupLoadBalanceHandlers();
       this._testModules = splitTestModules(
         weightTestModules(this._testModules),
-        split,
+        partitionCount,
         partitions
       );
       this._testem.emit(
@@ -82,7 +82,7 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
     } else {
       this._testModules = splitTestModules(
         this._testModules,
-        split,
+        partitionCount,
         partitions
       );
       this._testModules.forEach((moduleName) => {

--- a/addon-test-support/-private/patch-testem-output.js
+++ b/addon-test-support/-private/patch-testem-output.js
@@ -8,17 +8,16 @@
  * @returns {string} testName
  */
 export function updateTestName(urlParams, testName) {
-  const split = urlParams.get('split');
-  const loadBalance = urlParams.get('loadBalance');
+  const partitionCount = urlParams.get('partitionCount');
 
   const partition = urlParams.get('partition') || 1;
-  const browser = urlParams.get('browser') || 1;
+  const browser = urlParams.get('browser');
 
-  if (split && loadBalance) {
-    testName = `Exam Partition ${partition} - Browser Id ${browser} - ${testName}`;
-  } else if (split) {
+  if (partitionCount && browser) {
+    testName = `Exam Partition ${partition} - Browser Id ${browser} - ${testName}`
+  } else if (partitionCount) {
     testName = `Exam Partition ${partition} - ${testName}`;
-  } else if (loadBalance) {
+  } else if (browser) {
     testName = `Browser Id ${browser} - ${testName}`;
   }
 

--- a/addon-test-support/-private/split-test-modules.js
+++ b/addon-test-support/-private/split-test-modules.js
@@ -33,17 +33,17 @@ function isNotLintTest(name) {
  *
  * @export
  * @param {Array<string>} modules
- * @param {number} split
+ * @param {number} partitionCount
  * @param {number} partitions
  * @returns {Array<string>} tests
  */
-export default function splitTestModules(modules, split, partitions) {
-  if (split < 1) {
-    throw new Error('You must specify a split greater than 0');
+export default function splitTestModules(modules, partitionCount, partitions) {
+  if (partitionCount < 1) {
+    throw new Error('You must specify a partition-count greater than 0');
   }
 
-  const lintTestGroups = filterIntoGroups(modules, isLintTest, split);
-  const otherTestGroups = filterIntoGroups(modules, isNotLintTest, split);
+  const lintTestGroups = filterIntoGroups(modules, isLintTest, partitionCount);
+  const otherTestGroups = filterIntoGroups(modules, isNotLintTest, partitionCount);
   const tests = [];
 
   for (let i = 0; i < partitions.length; i++) {
@@ -56,12 +56,9 @@ export default function splitTestModules(modules, split, partitions) {
       );
     }
 
-    if (split < partition) {
-      throw new Error(
-        'You must specify partitions numbered less than or equal to your split value of ' +
-          split
-      );
-    } else if (partition < 1) {
+    if (partitionCount < partition) {
+      throw new Error('You must specify partitions numbered less than or equal to your partition-count value of ' + partitionCount);
+    } else  if (partition < 1) {
       throw new Error('You must specify partitions numbered greater than 0');
     }
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -5,7 +5,7 @@ const getChannelURL = require('ember-source-channel-url');
 const command = [
   'ember',
   'exam',
-  '--split',
+  '--partition-count',
   '3',
   '--parallel',
   '--random',

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -20,7 +20,7 @@ module.exports = TestCommand.extend({
 
   availableOptions: [
     {
-      name: 'split',
+      name: 'partition-count',
       type: Number,
       description: 'A number of files to split your tests across.'
     },
@@ -35,11 +35,10 @@ module.exports = TestCommand.extend({
       description: 'Runs your split tests on parallel child processes.'
     },
     {
-      name: 'load-balance',
-      type: Boolean,
-      default: false,
+      name: 'browser-count',
+      type: Number,
       description:
-        'Load balance test modules. Test modules will be sorted by weight from slowest (acceptance) to fastest (eslint).'
+        'The number of the browser(s) to run test suite with load balancing.'
     },
     {
       name: 'random',
@@ -83,7 +82,7 @@ module.exports = TestCommand.extend({
   },
 
   /**
-   *  Validates commandOptions
+   * Validates commandOptions
    *
    * @private
    * @param {Object} commandOptions
@@ -127,14 +126,14 @@ module.exports = TestCommand.extend({
     this.commands = this._validateOptions(commandOptions);
 
     // TODO: explore not mutating the commandOptions input
-    if (commandOptions.split) {
+    if (commandOptions.partitionCount) {
       commandOptions.query = addToQuery(
         commandOptions.query,
-        'split',
-        commandOptions.split
+        'partitionCount',
+        commandOptions.partitionCount
       );
 
-      process.env.EMBER_EXAM_SPLIT_COUNT = commandOptions.split;
+      process.env.EMBER_EXAM_SPLIT_COUNT = commandOptions.partitionCount;
 
       // Ignore the partition option when paralleling (we'll fill it in later)
       if (!commandOptions.parallel && commandOptions.partition) {
@@ -149,14 +148,6 @@ module.exports = TestCommand.extend({
           );
         }
       }
-    }
-
-    if (commandOptions.loadBalance) {
-      commandOptions.query = addToQuery(
-        commandOptions.query,
-        'loadBalance',
-        commandOptions.loadBalance
-      );
     }
 
     if (commandOptions.replayBrowser) {
@@ -207,12 +198,12 @@ module.exports = TestCommand.extend({
   _generateCustomConfigs(commandOptions) {
     const config = this._super._generateCustomConfigs.apply(this, arguments);
 
-    if (!commandOptions.loadBalance && !commandOptions.replayExecution && !commandOptions.parallel )
+    if (!commandOptions.browserCount && !commandOptions.replayExecution && !commandOptions.parallel )
       return config;
 
     config.testPage = getMultipleTestPages(config, commandOptions);
 
-    if (commandOptions.loadBalance || commandOptions.replayExecution) {
+    if (commandOptions.browserCount || commandOptions.replayExecution) {
       config.custom_browser_socket_events = this._addLoadBalancingBrowserSocketEvents(
         config
       );
@@ -241,11 +232,11 @@ module.exports = TestCommand.extend({
     const events = config.custom_browser_socket_events || {};
     const testExecutionFileName = `test-execution-${Date.now()}.json`;
     const browserExitHandler = function() {
-      const browserCount = Object.keys(config.testPage).length;
+      const totalBrowserCount = Object.keys(config.testPage).length;
       testemEvents.completedBrowsersHandler(
-        browserCount,
+        totalBrowserCount,
         ui,
-        commands.get('loadBalance'),
+        commands.get('browserCount'),
         testExecutionFileName,
         commands.get('writeExecutionFile')
       );
@@ -274,7 +265,7 @@ module.exports = TestCommand.extend({
       testemEvents.setModuleQueue(
         browserId,
         modules,
-        commands.get('loadBalance'),
+        commands.get('browserCount'),
         commands.get('replayExecution')
       );
     };

--- a/lib/utils/test-page-helper.js
+++ b/lib/utils/test-page-helper.js
@@ -12,13 +12,12 @@ const { addToUrl } = require('./query-helper');
  * @return {string} baseUrl
  */
 function _appendParamToBaseUrl(commandOptions, baseUrl) {
-  if (commandOptions.parallel || commandOptions.split) {
-    baseUrl = addToUrl(baseUrl, 'split', commandOptions.split);
+  if (commandOptions.parallel || commandOptions.partitionCount) {
+    baseUrl = addToUrl(baseUrl, 'partitionCount', commandOptions.partitionCount);
   }
-  // `loadBalance` is added to url when running replay-execution in order to emit `set-module-queue` in patch-test-loader.
-  if (commandOptions.loadBalance || commandOptions.replayExecution) {
+
+  if (commandOptions.browserCount || commandOptions.replayExecution) {
     const partitions = commandOptions.partition;
-    baseUrl = addToUrl(baseUrl, 'loadBalance', true);
     if (partitions) {
       for (let i = 0; i < partitions.length; i++) {
         baseUrl = addToUrl(baseUrl, 'partition', partitions[i]);
@@ -194,11 +193,11 @@ function getMultipleTestPages(config, commandOptions) {
   let browserIds = combineOptionValueIntoArray(commandOptions.partition);
   let appendingParam = 'partition';
 
-  if (commandOptions.loadBalance) {
+  if (commandOptions.browserCount) {
     appendingParam = 'browser';
-    browserIds = _getFilledArray(1, commandOptions.parallel);
-  } else if (commandOptions.parallel === 1 && browserIds.length === 0) {
-    browserIds = _getFilledArray(1, commandOptions.split);
+    browserIds = _getFilledArray(1, commandOptions.browserCount);
+  } else if (commandOptions.parallel && browserIds.length === 0) {
+    browserIds = _getFilledArray(1, commandOptions.partitionCount);
   } else if (commandOptions.replayExecution) {
     appendingParam = 'browser';
     browserIds = combineOptionValueIntoArray(commandOptions.replayBrowser);

--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -66,11 +66,11 @@ class TestemEvents {
    *
    * @param {number} browserId
    * @param {Array<string>} modules
-   * @param {boolean} loadBalance
+   * @param {number} browserCount
    * @param {boolean} replayExecution
    * @param {string} writeExecutionFile
    */
-  setModuleQueue(browserId, modules, loadBalance, replayExecution) {
+  setModuleQueue(browserId, modules, browserCount, replayExecution) {
     const replayExecutionMap = this.stateManager.getReplayExecutionMap();
 
     if (replayExecution) {
@@ -156,13 +156,13 @@ class TestemEvents {
    * Keep track of the number of browsers that completed executing its tests.
    * When all browsers complete, write test-execution.json to disk and clean up the stateManager
    *
-   * @param {number} browserCount
+   * @param {number} totalBrowserCount
    * @param {Object} ui
-   * @param {boolean} loadBalance
+   * @param {number} browserCount
    * @param {string} fileName
-   * @param {string} writeExecutionFile
+   * @param {boolean} writeExecutionFile
    */
-  completedBrowsersHandler(browserCount, ui, loadBalance, fileName, writeExecutionFile) {
+  completedBrowsersHandler(totalBrowserCount, ui, browserCount, fileName, writeExecutionFile) {
     let browsersCompleted = false;
 
     this.stateManager.incrementCompletedBrowsers();

--- a/lib/utils/tests-options-validator.js
+++ b/lib/utils/tests-options-validator.js
@@ -9,10 +9,10 @@ const semver = require('semver');
  *
  * @private
  * @param {Array<Number>} partitions
- * @param {Number} split
+ * @param {Number} partitionCount
  */
-function validatePartitions(partitions, split) {
-  validatePartitionSplit(partitions, split);
+function validatePartitions(partitions, partitionCount) {
+  validatePartitionSplit(partitions, partitionCount);
   validateElementsUnique(partitions, 'partition');
 }
 
@@ -63,12 +63,12 @@ function validateReplayBrowser(replayExecution, replayBrowser) {
  *
  * @private
  * @param {Array<Number>} partitions
- * @param {Number} split
+ * @param {Number} partitionCount
  */
-function validatePartitionSplit(partitions, split) {
-  if (!split) {
+function validatePartitionSplit(partitions, partitionCount) {
+  if (!partitionCount) {
     throw new SilentError(
-      'EmberExam: You must specify a `split` value in order to use `partition`.'
+      'EmberExam: You must specify a `partition-count` value in order to use `partition`.'
     );
   }
 
@@ -79,9 +79,9 @@ function validatePartitionSplit(partitions, split) {
         'EmberExam: Split tests are one-indexed, so you must specify partition values greater than or equal to 1.'
       );
     }
-    if (partition > split) {
+    if (partition > partitionCount) {
       throw new SilentError(
-        'EmberExam: You must specify `partition` values that are less than or equal to your `split` value.'
+        'EmberExam: You must specify `partition` values that are less than or equal to your `partition-count` value.'
       );
     }
   }
@@ -127,8 +127,15 @@ module.exports = class TestsOptionsValidator {
    */
   validateCommands() {
     const validatedOptions = new Map();
-    if (this.options.split || this.options.partition) {
-      validatedOptions.set('split', this.validateSplit());
+    if (this.options.split) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '`split` is being deprecated. You must use `partiton-count` instead.'
+      );
+      this.options.partitionCount = this.options.split;
+    }
+    if (this.options.partitionCount || this.options.partition) {
+      validatedOptions.set('partitionCount', this.validatePartitionCount());
     }
 
     // The parallel option accepts a number, which can be 0
@@ -148,8 +155,8 @@ module.exports = class TestsOptionsValidator {
       );
     }
 
-    if (this.options.loadBalance) {
-      validatedOptions.set('loadBalance', this.validateLoadBalance());
+    if (this.options.browserCount) {
+      validatedOptions.set('browserCount', this.validateBrowserCount());
     }
 
     if (this.options.replayExecution || this.options.replayBrowser) {
@@ -165,28 +172,28 @@ module.exports = class TestsOptionsValidator {
    *
    * @return {boolean}
    */
-  validateSplit() {
+  validatePartitionCount() {
     const options = this.options;
-    let split = options.split;
+    let partitionCount = options.partitionCount;
 
-    if (typeof split !== 'undefined' && split < 2) {
+    if (typeof partitionCount !== 'undefined' && partitionCount < 2) {
       // eslint-disable-next-line no-console
       console.warn(
-        'You should specify a number of files greater than 1 to split your tests across. Defaulting to 1 split which is the same as not using `split`.'
+        'You should specify a number of files greater than 1 to split your tests across. Defaulting to 1 partition-count which is the same as not using `partition-count`.'
       );
-      split = 1;
+      partitionCount = 1;
     }
 
     if (
-      typeof split !== 'undefined' &&
+      typeof partitionCount !== 'undefined' &&
       typeof this.options.replayBrowser !== 'undefined'
     ) {
       throw new SilentError(
-        'EmberExam: You must not use the `replay-browser` option with the `split` option.'
+        'EmberExam: You must not use the `replay-browser` option with the `partition-count` option.'
       );
     }
 
-    if (typeof split !== 'undefined' && this.options.replayExecution) {
+    if (typeof this.validatePartitionCount !== 'undefined' && this.options.replayExecution) {
       throw new SilentError(
         'EmberExam: You must not use the `replay-execution` option with the `split` option.'
       );
@@ -195,10 +202,10 @@ module.exports = class TestsOptionsValidator {
     const partitions = options.partition;
 
     if (typeof partitions !== 'undefined') {
-      validatePartitions(partitions, split);
+      validatePartitions(partitions, partitionCount);
     }
 
-    return !!split;
+    return !!partitionCount;
   }
 
   /**
@@ -230,9 +237,9 @@ module.exports = class TestsOptionsValidator {
       return false;
     }
 
-    if (!this.options.loadBalance) {
+    if (!this.options.browserCount) {
       throw new SilentError(
-        'EmberExam: You must run test suite with the `load-balance` option in order to use the `write-execution-file` option.'
+        'EmberExam: You must run test suite with the `browser-count` option in order to use the `write-execution-file` option.'
       );
     } else if (this.options.launch === 'false') {
       //When `--no-launch` option is passed, a value for launch in testem config is set to be string false.
@@ -251,6 +258,22 @@ module.exports = class TestsOptionsValidator {
    * @return {boolean}
    */
   validateParallel() {
+    if (!this.options.parallel) {
+      return false;
+    }
+
+    if (this.options.parallel && this.framework === 'mocha') {
+      throw new SilentError(
+        'EmberExam: Mocha does not currently support spliting tests on parallel child processes'
+      );
+    }
+
+    if (typeof this.options.browserCount !== 'undefined') {
+      throw new SilentError(
+        'EmberExam: You must not use the `browser-count` option with the `parallel` option.'
+      );
+    }
+
     if (typeof this.options.replayBrowser !== 'undefined') {
       throw new SilentError(
         'EmberExam: You must not use the `replay-browser` option with the `parallel` option.'
@@ -263,35 +286,27 @@ module.exports = class TestsOptionsValidator {
       );
     }
 
-    if (!this.options.loadBalance) {
-      if (!this.options.split) {
-        throw new SilentError(
-          'EmberExam: You must specify the `split` option in order to run your tests in parallel.'
-        );
-      } else if (this.options.parallel !== 1) {
-        throw new SilentError(
-          'EmberExam: When used with `split` or `partition`, `parallel` does not accept a value other than 1.'
-        );
-      }
-    }
-
-    if (this.options.parallel < 1) {
-      throw new SilentError(
-        'EmberExam: You must specify a value greater than 1 to `parallel`.'
-      );
+    if (!this.options.partitionCount) {
+      throw new SilentError('EmberExam: You must specify the `partition-count` option in order to run your tests in parallel');
     }
 
     return true;
   }
 
   /**
-   * Determines if we should run tests in load balance mode.
-   * options (`load-balance`).
+   * Determines if we should run tests in load balance mode with a number specified for `browser-count`.
+   * options (`browser-count`).
    *
    * @return {boolean}
    */
-  validateLoadBalance() {
-    // It's required to use ember-cli version 3.2.0 or greater to support the `load-balance` feature.
+  validateBrowserCount() {
+
+    if (this.options.browserCount && this.framework === 'mocha') {
+      throw new SilentError(
+        'Mocha does not currently support loading test modules in balance.'
+      );
+    }
+    // It's required to use ember-cli version 3.2.0 or greater to support the `browser-count` feature.
     const emberCliVersionRange = semver.validRange(this.emberCliVersion);
     if (semver.gtr('3.2.0', emberCliVersionRange)) {
       throw new SilentError(
@@ -301,26 +316,32 @@ module.exports = class TestsOptionsValidator {
 
     if (typeof this.options.replayBrowser !== 'undefined') {
       throw new SilentError(
-        'EmberExam: You must not use the `replay-browser` option with the `load-balance` option.'
+        'EmberExam: You must not use the `replay-browser` option with the `browser-count` option.'
       );
     }
 
     if (this.options.replayExecution) {
       throw new SilentError(
-        'EmberExam: You must not use the `replay-execution` option with the `load-balance` option.'
+        'EmberExam: You must not use the `replay-execution` option with the `browser-count` option.'
+      );
+    }
+
+    if (this.options.parallel) {
+      throw new SilentError(
+        'EmberExam: You must not use the `parallel` option with the `browser-count` option.'
       );
     }
 
     //When `--no-launch` option is passed, a value for launch in testem config is set to be string false.
     if (this.options.launch === 'false') {
       throw new SilentError(
-        'EmberExam: You must not use `no-launch` option with the `load-balance` option.'
+        'EmberExam: You must not use `no-launch` option with the `browser-count` option.'
       );
     }
 
-    if (!this.options.parallel) {
+    if (this.options.browserCount < 1) {
       throw new SilentError(
-        'EmberExam: You should specify the number of browsers to load-balance against using `parallel` when using `load-balance`.'
+        'EmberExam: You must specify a value greater than 1 to `browser-count`.'
       );
     }
 

--- a/node-tests/acceptance/exam-iterate-test.js
+++ b/node-tests/acceptance/exam-iterate-test.js
@@ -66,10 +66,10 @@ describe('Acceptance | Exam Iterate Command', function() {
       '--parallel'
     ]);
     return execution.then(assertExpectRejection, error => {
-      const splitErrorRE = /You must specify the `split` option in order to run your tests in parallel./g;
+      const partitionCountErrorRE = /You must specify the `partition-count` option in order to run your tests in parallel/g;
 
       assert.ok(
-        splitErrorRE.test(error.stderr),
+        partitionCountErrorRE.test(error.stderr),
         'expected stderr to contain the appropriate error message'
       );
       assert.equal(error.code, 1);

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -91,11 +91,11 @@ describe('Acceptance | Exam Command', function() {
     });
   });
 
-  describe('Split', function() {
-    it('splits the test suite but only runs the first partition', function() {
+  describe('PartitionCount', function() {
+    it('splits the test suite by `partition-count` but only runs the first partition', function() {
       return execa('ember', [
         'exam',
-        '--split',
+        '--partition-count',
         '3',
         '--path',
         'acceptance-dist'
@@ -105,10 +105,10 @@ describe('Acceptance | Exam Command', function() {
     });
 
     describe('Partition', function() {
-      it('splits the test suite and runs a specified partition', function() {
+      it('splits the test suite by `partition-count` and runs a specified partition', function() {
         return execa('ember', [
           'exam',
-          '--split',
+          '--partition-count',
           '3',
           '--partition',
           '2',
@@ -119,10 +119,10 @@ describe('Acceptance | Exam Command', function() {
         });
       });
 
-      it('splits the test suite and runs multiple specified partitions', function() {
+      it('splits the test suite by `partition-count`and runs multiple specified partitions', function() {
         return execa('ember', [
           'exam',
-          '--split',
+          '--partition-count',
           '3',
           '--partition',
           '1,3',
@@ -136,7 +136,7 @@ describe('Acceptance | Exam Command', function() {
       it('errors when running an invalid partition', function() {
         return execa('ember', [
           'exam',
-          '--split',
+          '--partition-count',
           '3',
           '--partition',
           '4',
@@ -145,7 +145,7 @@ describe('Acceptance | Exam Command', function() {
         ]).then(assertExpectRejection, error => {
           assert.ok(
             error.message.includes(
-              'You must specify `partition` values that are less than or equal to your `split` value.'
+              'You must specify `partition` values that are less than or equal to your `partition-count` value.'
             )
           );
         });
@@ -161,7 +161,7 @@ describe('Acceptance | Exam Command', function() {
         ]).then(assertExpectRejection, error => {
           assert.ok(
             error.message.includes(
-              'You must specify a `split` value in order to use `partition`.'
+              'You must specify a `partition-count` value in order to use `partition`.'
             )
           );
         });
@@ -174,7 +174,7 @@ describe('Acceptance | Exam Command', function() {
           'exam',
           '--path',
           'acceptance-dist',
-          '--split',
+          '--partition-count',
           '3',
           '--parallel'
         ]).then(child => {
@@ -185,7 +185,7 @@ describe('Acceptance | Exam Command', function() {
       it('runs multiple specified partitions in parallel', function() {
         return execa('ember', [
           'exam',
-          '--split',
+          '--partition-count',
           '3',
           '--partition',
           '1,3',
@@ -222,7 +222,7 @@ describe('Acceptance | Exam Command', function() {
     });
   });
 
-  describe('Load Balance', function() {
+  describe('Browser Count', function() {
     const unlinkFiles = [];
 
     function assertTestExecutionJson(output) {
@@ -245,16 +245,18 @@ describe('Acceptance | Exam Command', function() {
       unlinkFiles.length = 0;
     });
 
-    it('errors if `--parallel` is not passed', function() {
+    it('errors if `--parallel` is passed', function() {
       return execa('ember', [
         'exam',
         '--path',
         'acceptance-dist',
-        '--load-balance'
+        '--browser-count',
+        '2',
+        '--parallel'
       ]).then(assertExpectRejection, error => {
         assert.ok(
           error.message.includes(
-            'You should specify the number of browsers to load-balance against using `parallel` when using `load-balance`.'
+            'You must not use the `browser-count` option with the `parallel` option.'
           )
         );
       });
@@ -266,12 +268,11 @@ describe('Acceptance | Exam Command', function() {
         '--path',
         'acceptance-dist',
         '--write-execution-file',
-        '--load-balance',
-        '--parallel'
+        '--browser-count',
+        '1'
       ]).then(child => {
         const output = child.stdout;
         assertTestExecutionJson(output);
-        assertOutput(output, 'Browser Id', [1]);
         assert.equal(
           getNumberOfTests(output),
           getTotalNumberOfTests(output),
@@ -285,8 +286,7 @@ describe('Acceptance | Exam Command', function() {
         'exam',
         '--path',
         'acceptance-dist',
-        '--load-balance',
-        '--parallel',
+        '--browser-count',
         '3',
         '--write-execution-file'
       ]).then(child => {
@@ -306,13 +306,12 @@ describe('Acceptance | Exam Command', function() {
         'exam',
         '--path',
         'acceptance-dist',
-        '--load-balance',
-        '--split',
+        '--browser-count',
+        '3',
+        '--partition-count',
         '2',
         '--partition',
         '1',
-        '--parallel',
-        '3',
         '--write-execution-file'
       ]).then(child => {
         const output = child.stdout;
@@ -356,8 +355,7 @@ describe('Acceptance | Exam Command', function() {
           'exam',
           '--path',
           'failure-dist',
-          '--load-balance',
-          '--parallel',
+          '--browser-count',
           '2',
           '--write-execution-file'
         ]).then(assertExpectRejection, error => {

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -64,48 +64,42 @@ describe('ExamCommand', function() {
     });
 
     it('should set `partition` in the query option with one partition', function() {
-      return command.run({ split: 2, partition: [2] }).then(function() {
-        assert.equal(called.testRunOptions.query, 'split=2&partition=2');
-      });
-    });
-
-    it('should set `load-balance` in the query option', function() {
-      return command.run({ loadBalance: true, parallel: 1 }).then(function() {
-        assert.equal(called.testRunOptions.query, 'loadBalance');
+      return command.run({ partitionCount: 2, partition: [2] }).then(function() {
+        assert.equal(called.testRunOptions.query, 'partitionCount=2&partition=2');
       });
     });
 
     it('should set `partition` in the query option with multiple partitions', function() {
-      return command.run({ split: 2, partition: [1, 2] }).then(function() {
+      return command.run({ partitionCount: 2, partition: [1, 2] }).then(function() {
         assert.equal(
           called.testRunOptions.query,
-          'split=2&partition=1&partition=2'
+          'partitionCount=2&partition=1&partition=2'
         );
       });
     });
 
     it('should append `partition` to the query option', function() {
       return command
-        .run({ split: 2, partition: [2], query: 'someQuery=derp&hidepassed' })
+        .run({ partitionCount: 2, partition: [2], query: 'someQuery=derp&hidepassed' })
         .then(function() {
           assert.equal(
             called.testRunOptions.query,
-            'someQuery=derp&hidepassed&split=2&partition=2'
+            'someQuery=derp&hidepassed&partitionCount=2&partition=2'
           );
         });
     });
 
     it('should not append `partition` to the query option when parallelizing', function() {
       return command
-        .run({ split: 2, partition: [1, 2], parallel: 1 })
+        .run({ partitionCount: 2, partition: [1, 2], parallel: true })
         .then(function() {
-          assert.equal(called.testRunOptions.query, 'split=2');
+          assert.equal(called.testRunOptions.query, 'partitionCount=2');
         });
     });
 
     it('should not append `partition` to the query option when not parallelizing without partitions', function() {
-      return command.run({ split: 2 }).then(function() {
-        assert.equal(called.testRunOptions.query, 'split=2');
+      return command.run({ partitionCount: 2 }).then(function() {
+        assert.equal(called.testRunOptions.query, 'partitionCount=2');
       });
     });
 
@@ -134,8 +128,8 @@ describe('ExamCommand', function() {
       });
     });
 
-    it('should set split env var', function() {
-      return command.run({ split: 5 }).then(function() {
+    it('should set partitionCount env var', function() {
+      return command.run({ partitionCount: 5 }).then(function() {
         assert.equal(process.env.EMBER_EXAM_SPLIT_COUNT, '5');
       });
     });

--- a/node-tests/unit/utils/test-page-helper-test.js
+++ b/node-tests/unit/utils/test-page-helper-test.js
@@ -39,12 +39,12 @@ describe('TestPageHelper', function() {
 
   describe('getBrowserId', function() {
     it('should return the correct browserId', function() {
-      assert.equal(getBrowserId('loadBalance&browser=1'), 1);
+      assert.equal(getBrowserId('browser=1'), 1);
     });
 
     it('should return 0 if no browser param is found in the test page', function() {
       assert.throws(() => {
-        getBrowserId('loadBalance');
+        getBrowserId('partitionCount=2&&partition=1');
       }, /Browser Id can't be found./);
     });
   });
@@ -84,46 +84,37 @@ describe('TestPageHelper', function() {
   });
 
   describe('getCustomBaseUrl', function() {
-    it('should add `split` when `split` option is used', function() {
+    it('should add `partitionCount` when `partition-count` option is used', function() {
       const appendedUrl = getCustomBaseUrl(
-        { split: 3 },
+        { partitionCount: 3 },
         'tests/index.html?hidepassed'
       );
 
-      assert.deepEqual(appendedUrl, 'tests/index.html?hidepassed&split=3');
+      assert.deepEqual(appendedUrl, 'tests/index.html?hidepassed&partitionCount=3');
     });
 
-    it('should add `split` when `split` and `parallel` option are used', function() {
+    it('should add `partitionCount` when `partition-count` and `parallel` option are used', function() {
       const appendedUrl = getCustomBaseUrl(
-        { split: 5, parallel: true },
+        { partitionCount: 5, parallel: true },
         'tests/index.html?hidepassed'
       );
 
-      assert.deepEqual(appendedUrl, 'tests/index.html?hidepassed&split=5');
+      assert.deepEqual(appendedUrl, 'tests/index.html?hidepassed&partitionCount=5');
     });
 
-    it('should add `loadBalance` when `load-balance` option is used', function() {
+    it('should add `partitionCount` and `partition`when `partitionCount`, `partition`, and `browserCount` options are used.', function() {
       const appendedUrl = getCustomBaseUrl(
-        { loadBalance: 2 },
-        'tests/index.html?hidepassed'
-      );
-
-      assert.deepEqual(appendedUrl, 'tests/index.html?hidepassed&loadBalance');
-    });
-
-    it('should add `split`, `loadBalance`, and `partition` when `split`, `loadBalance`, and `partition` are used.', function() {
-      const appendedUrl = getCustomBaseUrl(
-        { split: 5, partition: [1, 2, 3], loadBalance: 2 },
+        { partitionCount: 5, partition: [1, 2, 3], browserCount: 1 },
         'tests/index.html?hidepassed'
       );
 
       assert.deepEqual(
         appendedUrl,
-        'tests/index.html?hidepassed&split=5&loadBalance&partition=1&partition=2&partition=3'
+        'tests/index.html?hidepassed&partitionCount=5&partition=1&partition=2&partition=3'
       );
     });
 
-    it('should add `loadBalance` when `replay-execution` and `replay-browser` are used', function() {
+    it('should not add any params when `replay-execution` and `replay-browser` are used', function() {
       const appendedUrl = getCustomBaseUrl(
         {
           replayExecution: 'test-execution-0000000.json',
@@ -132,48 +123,48 @@ describe('TestPageHelper', function() {
         'tests/index.html?hidepassed'
       );
 
-      assert.deepEqual(appendedUrl, 'tests/index.html?hidepassed&loadBalance');
+      assert.deepEqual(appendedUrl, 'tests/index.html?hidepassed');
     });
 
-    it('should add `split` to multiple test pages when `split` option is used', function() {
-      const appendedUrl = getCustomBaseUrl({ split: 3 }, [
+    it('should add `partitionCount` to multiple test pages when `partitionCount` option is used', function() {
+      const appendedUrl = getCustomBaseUrl({ partitionCount: 3 }, [
         'tests/index.html?hidepassed&derp=herp',
         'tests/index.html?hidepassed&foo=bar'
       ]);
 
       assert.deepEqual(appendedUrl, [
-        'tests/index.html?hidepassed&derp=herp&split=3',
-        'tests/index.html?hidepassed&foo=bar&split=3'
+        'tests/index.html?hidepassed&derp=herp&partitionCount=3',
+        'tests/index.html?hidepassed&foo=bar&partitionCount=3'
       ]);
     });
 
-    it('should add `split` when `split` to multiple test pages and `parallel` option are used', function() {
-      const appendedUrl = getCustomBaseUrl({ split: 5, parallel: true }, [
+    it('should add `partitionCount` when `partitionCount` to multiple test pages and `parallel` option are used', function() {
+      const appendedUrl = getCustomBaseUrl({ partitionCount: 5, parallel: true }, [
         'tests/index.html?hidepassed&derp=herp',
         'tests/index.html?hidepassed&foo=bar'
       ]);
 
       assert.deepEqual(appendedUrl, [
-        'tests/index.html?hidepassed&derp=herp&split=5',
-        'tests/index.html?hidepassed&foo=bar&split=5'
+        'tests/index.html?hidepassed&derp=herp&partitionCount=5',
+        'tests/index.html?hidepassed&foo=bar&partitionCount=5'
       ]);
     });
 
-    it('should add `loadBalance` to multiple test pages when `load-balance` option is used', function() {
-      const appendedUrl = getCustomBaseUrl({ loadBalance: 2 }, [
+    it('should not add any params to multiple test pages when `browser-count` option is used', function() {
+      const appendedUrl = getCustomBaseUrl({ browserCount: 2 }, [
         'tests/index.html?hidepassed&derp=herp',
         'tests/index.html?hidepassed&foo=bar'
       ]);
 
       assert.deepEqual(appendedUrl, [
-        'tests/index.html?hidepassed&derp=herp&loadBalance',
-        'tests/index.html?hidepassed&foo=bar&loadBalance'
+        'tests/index.html?hidepassed&derp=herp',
+        'tests/index.html?hidepassed&foo=bar'
       ]);
     });
 
-    it('should add `split`, `loadBalance`, and `partition` to multiple test pages when `split`, `loadBalance`, and `partition` are used.', function() {
+    it('should add `partitionCount`, and `partition` to multiple test pages when `partition-count`, `browser-count`, and `partition` are used.', function() {
       const appendedUrl = getCustomBaseUrl(
-        { split: 5, partition: [1, 2, 3], loadBalance: 2 },
+        { partitionCount: 5, partition: [1, 2, 3], browserCount: 2 },
         [
           'tests/index.html?hidepassed&derp=herp',
           'tests/index.html?hidepassed&foo=bar'
@@ -181,12 +172,12 @@ describe('TestPageHelper', function() {
       );
 
       assert.deepEqual(appendedUrl, [
-        'tests/index.html?hidepassed&derp=herp&split=5&loadBalance&partition=1&partition=2&partition=3',
-        'tests/index.html?hidepassed&foo=bar&split=5&loadBalance&partition=1&partition=2&partition=3'
+        'tests/index.html?hidepassed&derp=herp&partitionCount=5&partition=1&partition=2&partition=3',
+        'tests/index.html?hidepassed&foo=bar&partitionCount=5&partition=1&partition=2&partition=3'
       ]);
     });
 
-    it('should add `loadBalance` to multiple test pages when `replay-execution` and `replay-browser` are used', function() {
+    it('should not add any params to multiple test pages when `replay-execution` and `replay-browser` are used', function() {
       const appendedUrl = getCustomBaseUrl(
         {
           replayExecution: 'test-execution-0000000.json',
@@ -199,8 +190,8 @@ describe('TestPageHelper', function() {
       );
 
       assert.deepEqual(appendedUrl, [
-        'tests/index.html?hidepassed&derp=herp&loadBalance',
-        'tests/index.html?hidepassed&foo=bar&loadBalance'
+        'tests/index.html?hidepassed&derp=herp',
+        'tests/index.html?hidepassed&foo=bar'
       ]);
     });
   });
@@ -209,110 +200,110 @@ describe('TestPageHelper', function() {
     it('should have multiple test pages with no partitions specified', function() {
       const testPages = getMultipleTestPages(
         { testPage: 'tests/index.html?hidepassed' },
-        { parallel: 1, split: 2 }
+        { parallel: true, partitionCount: 2 }
       );
 
       assert.deepEqual(testPages, [
-        'tests/index.html?hidepassed&split=2&partition=1',
-        'tests/index.html?hidepassed&split=2&partition=2'
+        'tests/index.html?hidepassed&partitionCount=2&partition=1',
+        'tests/index.html?hidepassed&partitionCount=2&partition=2'
       ]);
     });
 
     it('should have multiple test pages with specified partitions', function() {
       const testPages = getMultipleTestPages(
         { testPage: 'tests/index.html?hidepassed' },
-        { parallel: 1, split: 4, partition: [3, 4] }
+        { parallel: true, partitionCount: 4, partition: [3, 4] }
       );
 
       assert.deepEqual(testPages, [
-        'tests/index.html?hidepassed&split=4&partition=3',
-        'tests/index.html?hidepassed&split=4&partition=4'
+        'tests/index.html?hidepassed&partitionCount=4&partition=3',
+        'tests/index.html?hidepassed&partitionCount=4&partition=4'
       ]);
     });
 
     it('should have multiple test pages for each test_page in the config file with no partitions specified', function() {
       const testPages = getMultipleTestPages(
         { configFile: 'testem.multiple-test-page.js' },
-        { parallel: 1, split: 2 }
+        { parallel: true, partitionCount: 2 }
       );
 
       assert.deepEqual(testPages, [
-        'tests/index.html?hidepassed&derp=herp&split=2&partition=1',
-        'tests/index.html?hidepassed&derp=herp&split=2&partition=2',
-        'tests/index.html?hidepassed&foo=bar&split=2&partition=1',
-        'tests/index.html?hidepassed&foo=bar&split=2&partition=2'
+        'tests/index.html?hidepassed&derp=herp&partitionCount=2&partition=1',
+        'tests/index.html?hidepassed&derp=herp&partitionCount=2&partition=2',
+        'tests/index.html?hidepassed&foo=bar&partitionCount=2&partition=1',
+        'tests/index.html?hidepassed&foo=bar&partitionCount=2&partition=2'
       ]);
     });
 
     it('should have multiple test pages for each test_page in the config file with partitions specified', function() {
       const testPages = getMultipleTestPages(
         { configFile: 'testem.multiple-test-page.js' },
-        { parallel: 1, split: 4, partition: [3, 4] }
+        { parallel: true, partitionCount: 4, partition: [3, 4] }
       );
 
       assert.deepEqual(testPages, [
-        'tests/index.html?hidepassed&derp=herp&split=4&partition=3',
-        'tests/index.html?hidepassed&derp=herp&split=4&partition=4',
-        'tests/index.html?hidepassed&foo=bar&split=4&partition=3',
-        'tests/index.html?hidepassed&foo=bar&split=4&partition=4'
+        'tests/index.html?hidepassed&derp=herp&partitionCount=4&partition=3',
+        'tests/index.html?hidepassed&derp=herp&partitionCount=4&partition=4',
+        'tests/index.html?hidepassed&foo=bar&partitionCount=4&partition=3',
+        'tests/index.html?hidepassed&foo=bar&partitionCount=4&partition=4'
       ]);
     });
 
-    it('should have a test page with `loadBalance` when no specified number of browser', function() {
+    it('should have a test page with `browser` param with specified number of browser', function() {
       const testPages = getMultipleTestPages(
         { testPage: 'tests/index.html?hidepassed' },
-        { loadBalance: true, parallel: 1 }
+        { browserCount: 1 }
       );
 
       assert.deepEqual(testPages, [
-        'tests/index.html?hidepassed&loadBalance&browser=1'
+        'tests/index.html?hidepassed&browser=1'
       ]);
     });
 
-    it('should have multiple test page with `loadBalance` with splitting when no specified number of browser', function() {
+    it('should have a test page with `partitionCount` and `browser` with splitting when specified number of browser', function() {
       const testPages = getMultipleTestPages(
         { testPage: 'tests/index.html?hidepassed' },
-        { loadBalance: true, parallel: 1, split: 2 }
+        { browserCount: 1, partitionCount: 2 }
       );
 
       assert.deepEqual(testPages, [
-        'tests/index.html?hidepassed&split=2&loadBalance&browser=1'
+        'tests/index.html?hidepassed&partitionCount=2&browser=1'
       ]);
     });
 
-    it('should have multiple test pages with test loading balanced, no specified partitions and no splitting', function() {
+    it('should have multiple test pages with specificed number of browsers, no specified partitions and no splitting', function() {
       const testPages = getMultipleTestPages(
         { testPage: 'tests/index.html?hidepassed' },
-        { loadBalance: true, parallel: 2 }
+        { browserCount: 2 }
       );
 
       assert.deepEqual(testPages, [
-        'tests/index.html?hidepassed&loadBalance&browser=1',
-        'tests/index.html?hidepassed&loadBalance&browser=2'
+        'tests/index.html?hidepassed&browser=1',
+        'tests/index.html?hidepassed&browser=2'
       ]);
     });
 
-    it('should have multiple test pages with test loading balanced, no specified partitions and no splitting', function() {
+    it('should have multiple test pages with `browserCount`, `partitionCount`, and `partition` specified', function() {
       const testPages = getMultipleTestPages(
         { testPage: 'tests/index.html?hidepassed' },
-        { loadBalance: true, parallel: 2, split: 3, partition: [2, 3] }
+        { browserCount: 2, partitionCount: 3, partition: [2, 3] }
       );
 
       assert.deepEqual(testPages, [
-        'tests/index.html?hidepassed&split=3&loadBalance&partition=2&partition=3&browser=1',
-        'tests/index.html?hidepassed&split=3&loadBalance&partition=2&partition=3&browser=2'
+        'tests/index.html?hidepassed&partitionCount=3&partition=2&partition=3&browser=1',
+        'tests/index.html?hidepassed&partitionCount=3&partition=2&partition=3&browser=2'
       ]);
     });
 
-    it('should have multiple test pages for each test_page in the config file with partitions specified and test loading balanced', function() {
+    it('should have multiple test pages for each test_page in the config file with partitions specified and browser Ids', function() {
       const testPages = getMultipleTestPages(
         { configFile: 'testem.multiple-test-page.js' },
-        { loadBalance: true, parallel: 1, split: 4, partition: [3, 4] }
+        { browserCount: 1, partitionCount: 4, partition: [3, 4] }
       );
 
       assert.deepEqual(testPages, [
-        'tests/index.html?hidepassed&derp=herp&split=4&loadBalance&partition=3&partition=4&browser=1',
-        'tests/index.html?hidepassed&foo=bar&split=4&loadBalance&partition=3&partition=4&browser=1'
+        'tests/index.html?hidepassed&derp=herp&partitionCount=4&partition=3&partition=4&browser=1',
+        'tests/index.html?hidepassed&foo=bar&partitionCount=4&partition=3&partition=4&browser=1'
       ]);
     });
 
@@ -323,7 +314,7 @@ describe('TestPageHelper', function() {
       );
 
       assert.deepEqual(testPages, [
-        'tests/index.html?hidepassed&loadBalance&browser=2'
+        'tests/index.html?hidepassed&browser=2'
       ]);
     });
   });

--- a/node-tests/unit/utils/tests-options-validator-test.js
+++ b/node-tests/unit/utils/tests-options-validator-test.js
@@ -15,16 +15,16 @@ const TestExecutionJson = {
 describe('TestOptionsValidator', function() {
   function validateCommand(validator, cmd) {
     switch (cmd) {
-      case 'Split':
-        return validator.validateSplit();
+      case 'PartitionCount':
+        return validator.validatePartitionCount();
       case 'Random':
         return validator.validateRandom();
       case 'Parallel':
         return validator.validateParallel();
       case 'writeExecutionFile':
         return validator.validateWriteExecutionFile();
-      case 'LoadBalance':
-        return validator.validateLoadBalance();
+      case 'BrowserCount':
+        return validator.validateBrowserCount();
       case 'ReplayExecution':
         return validator.validateReplayExecution();
       default:
@@ -73,61 +73,61 @@ describe('TestOptionsValidator', function() {
     /* eslint-enable no-console */
   }
 
-  describe('shouldSplit', function() {
-    function shouldSplitThrows(options, message) {
-      shouldThrow('Split', options, message);
+  describe('shouldSplitByPartitionCount', function() {
+    function shouldSplitByPartitionCountThrows(options, message) {
+      shouldThrow('PartitionCount', options, message);
     }
 
-    function shouldSplitEqual(options, message) {
-      shouldEqual('Split', options, message);
+    function shouldSplitByPartitionCountEqual(options, message) {
+      shouldEqual('PartitionCount', options, message);
     }
 
-    it('should log a warning if `split` is less than 2', function() {
+    it('should log a warning if `partitionCount` is less than 2', function() {
       shouldWarn(
-        'Split',
-        { split: 1 },
-        'You should specify a number of files greater than 1 to split your tests across. Defaulting to 1 split which is the same as not using `split`.'
+        'PartitionCount',
+        { partitionCount: 1 },
+        'You should specify a number of files greater than 1 to split your tests across. Defaulting to 1 partition-count which is the same as not using `partition-count`.'
       );
     });
 
-    it('should throw an error if `partition` is used without `split`', function() {
-      shouldSplitThrows(
+    it('should throw an error if `partition` is used without `partition-count`', function() {
+      shouldSplitByPartitionCountThrows(
         { partition: [1] },
-        /You must specify a `split` value in order to use `partition`/
+        /You must specify a `partition-count` value in order to use `partition`/
       );
     });
 
     it('should throw an error if `partition` contains a value less than 1', function() {
-      shouldSplitThrows(
-        { split: 2, partition: [1, 0] },
+      shouldSplitByPartitionCountThrows(
+        { partitionCount: 2, partition: [1, 0] },
         /Split tests are one-indexed, so you must specify partition values greater than or equal to 1./
       );
     });
 
-    it('should throw an error if `partition` contains a value greater than `split`', function() {
-      shouldSplitThrows(
-        { split: 2, partition: [1, 3] },
-        /You must specify `partition` values that are less than or equal to your `split` value./
+    it('should throw an error if `partition` contains a value greater than `partition-count`', function() {
+      shouldSplitByPartitionCountThrows(
+        { partitionCount: 2, partition: [1, 3] },
+        /You must specify `partition` values that are less than or equal to your `partition-count` value./
       );
     });
 
     it('should throw an error if `partition` contains duplicate values', function() {
-      shouldSplitThrows(
-        { split: 2, partition: [1, 2, 1] },
+      shouldSplitByPartitionCountThrows(
+        { partitionCount: 2, partition: [1, 2, 1] },
         /You cannot specify the same partition value twice. 1 is repeated./
       );
     });
 
-    it('should return true if using `split`', function() {
-      shouldSplitEqual({ split: 2 }, true);
+    it('should return true if using `partition-count`', function() {
+      shouldSplitByPartitionCountEqual({ partitionCount: 2 }, true);
     });
 
-    it('should return true if using `split` and `partition`', function() {
-      shouldSplitEqual({ split: 2, partition: [1] }, true);
+    it('should return true if using `partition-count` and `partition`', function() {
+      shouldSplitByPartitionCountEqual({ partitionCount: 2, partition: [1] }, true);
     });
 
-    it('should return false if not using `split`', function() {
-      shouldSplitEqual({}, false);
+    it('should return false if not using `partition-count`', function() {
+      shouldSplitByPartitionCountEqual({}, false);
     });
   });
 
@@ -162,18 +162,18 @@ describe('TestOptionsValidator', function() {
   });
 
   describe('shouldParallelize', function() {
-    it('should throw an error if `split` is not being used', function() {
+    it('should throw an error if `partition-count` is not being used', function() {
       shouldThrow(
         'Parallel',
-        { parallel: 1 },
-        /You must specify the `split` option in order to run your tests in parallel/
+        { parallel: true },
+        /You must specify the `partition-count` option in order to run your tests in parallel/
       );
     });
 
     it('should throw an error if used with `replay-execution`', function() {
       shouldThrow(
         'Parallel',
-        { replayExecution: 'abc', parallel: 1 },
+        { replayExecution: 'abc', parallel: true },
         /You must not use the `replay-execution` option with the `parallel` option./
       );
     });
@@ -181,29 +181,17 @@ describe('TestOptionsValidator', function() {
     it('should throw an error if used with `replay-browser`', function() {
       shouldThrow(
         'Parallel',
-        { replayBrowser: 2, parallel: 1 },
+        { replayBrowser: 2, parallel: true },
         /You must not use the `replay-browser` option with the `parallel` option./
       );
     });
 
-    it('should throw an error if parallel is > 1 when used with `split`', function() {
-      shouldThrow(
-        'Parallel',
-        { split: 2, parallel: 2 },
-        /When used with `split` or `partition`, `parallel` does not accept a value other than 1./
-      );
-    });
-
-    it('should throw an error if 0 is passed while loadBalance is specified', function() {
-      shouldThrow(
-        'Parallel',
-        { loadBalance: 2, parallel: 0 },
-        /You must specify a value greater than 1 to `parallel`./
-      );
+    it('should throw an error if used with `browser-count`', function() {
+      shouldThrow('Parallel', { browserCount: 2, parallel: true }, /You must not use the `browser-count` option with the `parallel` option./);
     });
 
     it('should return true', function() {
-      shouldEqual('Parallel', { split: 2, parallel: 1 }, true);
+      shouldEqual('Parallel', { partitionCount: 2, partition: 1, parallel: true }, true);
     });
   });
 
@@ -212,35 +200,34 @@ describe('TestOptionsValidator', function() {
       shouldEqual(
         'writeExecutionFile',
         {
-          loadBalance: true,
-          parallel: 2,
+          browser: 2,
           launch: 'false'
         },
         false
       );
     });
 
-    it('should throw an error if `write-execution-file` is used without `load-balance`', function() {
+    it('should throw an error if `write-execution-file` is used without `browser-count`', function() {
       shouldThrow(
         'writeExecutionFile',
         { writeExecutionFile: true },
-        /You must run test suite with the `load-balance` option in order to use the `write-execution-file` option./
+        /You must run test suite with the `browser-count` option in order to use the `write-execution-file` option./
       );
     });
 
-    it('should throw an error if `write-execution-file` is used without `load-balance`', function() {
+    it('should throw an error if `write-execution-file` is used without `browser-count`', function() {
       shouldThrow(
         'writeExecutionFile',
         {
-          split: 2,
+          partitionCount: 2,
           partition: 1,
           writeExecutionFile: true
         },
-        /You must run test suite with the `load-balance` option in order to use the `write-execution-file` option./
+        /You must run test suite with the `browser-count` option in order to use the `write-execution-file` option./
       );
     });
 
-    it('should throw an error if `write-execution-file` is used without `load-balance`', function() {
+    it('should throw an error if `write-execution-file` is used without `browser-count`', function() {
       shouldThrow(
         'writeExecutionFile',
         {
@@ -248,7 +235,7 @@ describe('TestOptionsValidator', function() {
           replayBrowser: [1, 2],
           writeExecutionFile: true
         },
-        /You must run test suite with the `load-balance` option in order to use the `write-execution-file` option./
+        /You must run test suite with the `browser-count` option in order to use the `write-execution-file` option./
       );
     });
 
@@ -256,8 +243,7 @@ describe('TestOptionsValidator', function() {
       shouldThrow(
         'writeExecutionFile',
         {
-          loadBalance: true,
-          parallel: 1,
+          browserCount: 1,
           launch: 'false',
           writeExecutionFile: true
         },
@@ -269,7 +255,7 @@ describe('TestOptionsValidator', function() {
       shouldEqual(
         'writeExecutionFile',
         {
-          loadBalance: true,
+          browserCount: 2,
           parallel: 2,
           writeExecutionFile: true
         },
@@ -278,11 +264,11 @@ describe('TestOptionsValidator', function() {
     });
   });
 
-  describe('shouldLoadBalance', function() {
+  describe('shouldBrowserCount', function() {
     it('should throw an error if ember-cli version is below 3.2.0', function() {
       shouldThrow(
-        'LoadBalance',
-        { loadBalance: true, replayExecution: 'abc' },
+        'BrowserCount',
+        { browserCount: 1, replayExecution: 'abc' },
         /You must be using ember-cli version \^3.2.0 for this feature to work properly./,
         '3.0.0'
       );
@@ -290,8 +276,8 @@ describe('TestOptionsValidator', function() {
 
     it('should throw an error if ember-cli version is ~3.1.0', function() {
       shouldThrow(
-        'LoadBalance',
-        { loadBalance: true, replayExecution: 'abc' },
+        'BrowserCount',
+        { browserCount: 2, replayExecution: 'abc' },
         /You must be using ember-cli version \^3.2.0 for this feature to work properly./,
         '~3.1.0'
       );
@@ -299,46 +285,46 @@ describe('TestOptionsValidator', function() {
 
     it('should throw an error if `replayExecution` is passed', function() {
       shouldThrow(
-        'LoadBalance',
-        { loadBalance: true, replayExecution: 'abc' },
-        /You must not use the `replay-execution` option with the `load-balance` option./
+        'BrowserCount',
+        { browserCount: 1, replayExecution: 'abc' },
+        /You must not use the `replay-execution` option with the `browser-count` option./
       );
     });
 
     it('should throw an error if `replayBrowser` is passed', function() {
       shouldThrow(
-        'LoadBalance',
-        { loadBalance: true, replayBrowser: 3 },
-        /You must not use the `replay-browser` option with the `load-balance` option./
+        'BrowserCount',
+        { browserCount: 1, replayBrowser: 3 },
+        /You must not use the `replay-browser` option with the `browser-count` option./
       );
     });
 
-    it('should throw an error if `parallel` is not defined', function() {
+    it('should throw an error if `parallel` is defined', function() {
       shouldThrow(
-        'LoadBalance',
-        { loadBalance: true },
-        /You should specify the number of browsers to load-balance against using `parallel` when using `load-balance`./
+        'BrowserCount',
+        { browserCount: 2, parallel: true },
+        /You must not use the `parallel` option with the `browser-count` option./
       );
     });
 
-    it('should throw an error if `parallel` has a value less than 1', function() {
+    it('should throw an error if `browser-count` has a value less than 1', function() {
       shouldThrow(
-        'LoadBalance',
-        { loadBalance: true, parallel: 0 },
-        /You should specify the number of browsers to load-balance against using `parallel` when using `load-balance`./
+        'BrowserCount',
+        { browserCount: 0 },
+        /You must specify a value greater than 1 to `browser-count`./
       );
     });
 
     it('should throw an error if `no-launch` is passed', function() {
       shouldThrow(
-        'LoadBalance',
-        { loadBalance: true, parallel: 0, launch: 'false' },
-        /You must not use `no-launch` option with the `load-balance` option./
+        'BrowserCount',
+        { browserCount: 1, launch: 'false' },
+        /You must not use `no-launch` option with the `browser-count` option./
       );
     });
 
     it('should return true', function() {
-      shouldEqual('LoadBalance', { loadBalance: true, parallel: 3 }, true);
+      shouldEqual('BrowserCount', { browserCount : 3 }, true);
     });
   });
 

--- a/tests/unit/mocha/test-loader-test.js
+++ b/tests/unit/mocha/test-loader-test.js
@@ -46,7 +46,7 @@ describe('Unit | test-loader', function() {
   it('loads modules from a specified partition', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('partition', 3).set('split', 4)
+      new Map().set('partition', 3).set('partitionCount', 4)
     );
     testLoader.loadModules();
 
@@ -59,7 +59,7 @@ describe('Unit | test-loader', function() {
   it('loads modules from multiple specified partitions', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('partition', [1, 3]).set('split', 4)
+      new Map().set('partition', [1, 3]).set('partitionCount', 4)
     );
     testLoader.loadModules();
 
@@ -74,7 +74,7 @@ describe('Unit | test-loader', function() {
   it('loads modules from the first partition by default', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('split', 4)
+      new Map().set('partitionCount', 4)
     );
     testLoader.loadModules();
 
@@ -87,7 +87,7 @@ describe('Unit | test-loader', function() {
   it('handles params as strings', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('partition', '3').set('split', '4')
+      new Map().set('partition', '3').set('partitionCount', '4')
     );
     testLoader.loadModules();
 
@@ -97,21 +97,21 @@ describe('Unit | test-loader', function() {
     ]);
   });
 
-  it('throws an error if splitting less than one', function() {
+  it('throws an error if partition-countvalue is less than one', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('split', 0)
+      new Map().set('partitionCount', 0)
     );
 
     expect(() => {
       testLoader.loadModules();
-    }).to.throw(/You must specify a split greater than 0/);
+    }).to.throw(/You must specify a partitionCount greater than 0/);
   });
 
   it('throws an error if partition isn\'t a number', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('split', 2).set('partition', 'foo')
+      new Map().set('partitionCount', 2).set('partition', 'foo')
     );
 
     expect(() => {
@@ -124,7 +124,7 @@ describe('Unit | test-loader', function() {
   it('throws an error if partition isn\'t a number with multiple partitions', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('split', 2).set('partition', [1, 'foo'])
+      new Map().set('partitionCount', 2).set('partition', [1, 'foo'])
     );
 
     expect(() => {
@@ -137,33 +137,33 @@ describe('Unit | test-loader', function() {
   it('throws an error if loading partition greater than split number', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('split', 2).set('partition', 3)
+      new Map().set('partitionCount', 2).set('partition', 3)
     );
 
     expect(() => {
       testLoader.loadModules();
     }).to.throw(
-      /You must specify partitions numbered less than or equal to your split value/
+      /You must specify partitions numbered less than or equal to your partition-count value/
     );
   });
 
   it('throws an error if loading partition greater than split number with multiple partitions', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('split', 2).set('partition', [2, 3])
+      new Map().set('partitionCount', 2).set('partition', [2, 3])
     );
 
     expect(() => {
       testLoader.loadModules();
     }).to.throw(
-      /You must specify partitions numbered less than or equal to your split value/
+      /You must specify partitions numbered less than or equal to your partition-count value/
     );
   });
 
   it('throws an error if loading partition less than one', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('split', 2).set('partition', 0)
+      new Map().set('partitionCount', 2).set('partition', 0)
     );
 
     expect(() => {
@@ -177,7 +177,7 @@ describe('Unit | test-loader', function() {
       new Map()
         .set('nolint', true)
         .set('partition', 4)
-        .set('split', 4)
+        .set('partitionCount', 4)
     );
     testLoader.loadModules();
 
@@ -191,7 +191,7 @@ describe('Unit | test-loader', function() {
   it('load works without non-lint tests', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('partition', 4).set('split', 4)
+      new Map().set('partition', 4).set('partitionCount', 4)
     );
 
     window.requirejs.entries = {
@@ -209,7 +209,7 @@ describe('Unit | test-loader', function() {
   it('load works with a double-digit single partition', function() {
     const testLoader = new EmberExamTestLoader(
       this.testem,
-      new Map().set('partition', '10').set('split', 10)
+      new Map().set('partition', '10').set('partitionCount', 10)
     );
 
     window.requirejs.entries = {

--- a/tests/unit/mocha/testem-output-test.js
+++ b/tests/unit/mocha/testem-output-test.js
@@ -3,41 +3,40 @@ import { expect } from 'chai';
 import TestemOutput from 'ember-exam/test-support/-private/patch-testem-output';
 
 describe('Unit | patch-testem-output', () => {
-  it('add partition number to test name when `split` is passed', function() {
+  it('add partition number to test name when `partitionCount` is passed', function() {
     expect(
       TestemOutput.updateTestName(
-        new Map().set('split', 2),
+        new Map().set('partitionCount', 2),
         'test_module | test_name'
       )
     ).to.deepEqual('Exam Partition 1 - test_module | test_name');
   });
 
-  it('add partition number to test name when `split` and `partition` are passed', function() {
+  it('add partition number to test name when `partitionCount` and `partition` are passed', function() {
     expect(
       TestemOutput.updateTestName(
-        new Map().set('split', 2).set('partition', 2),
+        new Map().set('partitionCount', 2).set('partition', 2),
         'test_module | test_name'
       )
     ).to.deepEqual('Exam Partition 2 - test_module | test_name');
   });
 
-  it('add browser number to test name when `loadBalance` and `browser` are passed', function() {
+  it('add browser number to test name when `browser` is passed', function() {
     expect(
       TestemOutput.updateTestName(
-        new Map().set('loadBalance', 2).set('browser', 1),
+        new Map().set('browser', 1),
         'test_module | test_name'
       )
     ).to.deepEqual('Browser Id 1 - test_module | test_name');
   });
 
-  it('add partition number, browser number to test name when `split`, `partition`, `browser`, and `loadBalance` are  passed', function() {
+  it('add partition number, browser number to test name when `partitionCount`, `partition` and `browser` are  passed', function() {
     expect(
       TestemOutput.updateTestName(
         new Map()
-          .set('split', 2)
+          .set('partitionCount', 2)
           .set('partition', 2)
-          .set('browser', 1)
-          .set('loadBalance', 2),
+          .set('browser', 1),
         'test_module | test_name'
       )
     ).to.deepEqual('Exam Partition 2 - Browser Id 1 - test_module | test_name');

--- a/tests/unit/qunit/test-loader-test.js
+++ b/tests/unit/qunit/test-loader-test.js
@@ -63,7 +63,7 @@ test('loads all test modules by default', function(assert) {
 test('loads modules from a specified partition', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('partition', 3).set('split', 4),
+    new Map().set('partition', 3).set('partitionCount', 4),
     this.qunit
   );
   testLoader.loadModules();
@@ -74,7 +74,7 @@ test('loads modules from a specified partition', function(assert) {
 test('loads modules from multiple specified partitions', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('partition', [1, 3]).set('split', 4),
+    new Map().set('partition', [1, 3]).set('partitionCount', 4),
     this.qunit
   );
   testLoader.loadModules();
@@ -90,7 +90,7 @@ test('loads modules from multiple specified partitions', function(assert) {
 test('loads modules from the first partition by default', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('split', 4),
+    new Map().set('partitionCount', 4),
     this.qunit
   );
   testLoader.loadModules();
@@ -101,7 +101,7 @@ test('loads modules from the first partition by default', function(assert) {
 test('handles params as strings', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('partition', 3).set('split', 4),
+    new Map().set('partition', 3).set('partitionCount', 4),
     this.qunit
   );
   testLoader.loadModules();
@@ -109,22 +109,22 @@ test('handles params as strings', function(assert) {
   assert.deepEqual(this.requiredModules, ['test-3-test.jshint', 'test-3-test']);
 });
 
-test('throws an error if splitting less than one', function(assert) {
+test('throws an error if splitting by partition-count less than one', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('split', 0),
+    new Map().set('partitionCount', 0),
     this.qunit
   );
 
   assert.throws(() => {
     testLoader.loadModules();
-  }, /You must specify a split greater than 0/);
+  }, /You must specify a partition-count greater than 0/);
 });
 
 test('throws an error if partition isn\'t a number', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('split', 2).set('partition', 'foo'),
+    new Map().set('partitionCountt', 2).set('partition', 'foo'),
     this.qunit
   );
 
@@ -136,7 +136,7 @@ test('throws an error if partition isn\'t a number', function(assert) {
 test('throws an error if partition isn\'t a number with multiple partitions', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('split', 2).set('partition', [1, 'foo']),
+    new Map().set('partitionCount', 2).set('partition', [1, 'foo']),
     this.qunit
   );
 
@@ -145,34 +145,34 @@ test('throws an error if partition isn\'t a number with multiple partitions', fu
   }, /You must specify numbers for partition \(you specified '1,foo'\)/);
 });
 
-test('throws an error if loading partition greater than split number', function(assert) {
+test('throws an error if loading partition greater than partition-count number', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('split', 2).set('partition', 3),
+    new Map().set('partitionCount', 2).set('partition', 3),
     this.qunit
   );
 
   assert.throws(() => {
     testLoader.loadModules();
-  }, /You must specify partitions numbered less than or equal to your split value/);
+  }, /You must specify partitions numbered less than or equal to your partition-count value/);
 });
 
-test('throws an error if loading partition greater than split number with multiple partitions', function(assert) {
+test('throws an error if loading partition greater than partition-count number with multiple partitions', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('split', 2).set('partition', [2, 3]),
+    new Map().set('partitionCount', 2).set('partition', [2, 3]),
     this.qunit
   );
 
   assert.throws(() => {
     testLoader.loadModules();
-  }, /You must specify partitions numbered less than or equal to your split value/);
+  }, /You must specify partitions numbered less than or equal to your partition-count value/);
 });
 
 test('throws an error if loading partition less than one', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('split', 2).set('partition', 0),
+    new Map().set('partitionCount', 2).set('partition', 0),
     this.qunit
   );
 
@@ -185,7 +185,7 @@ test('load works without lint tests', function(assert) {
   QUnit.urlParams.nolint = true;
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('partition', 4).set('split', 4),
+    new Map().set('partition', 4).set('partitionCount', 4),
     this.qunit
   );
 
@@ -206,7 +206,7 @@ test('load works without non-lint tests', function(assert) {
 
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('partition', 4).set('split', 4),
+    new Map().set('partition', 4).set('partitionCount', 4),
     this.qunit
   );
 
@@ -231,7 +231,7 @@ test('load works with a double-digit single partition', function(assert) {
 
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('partition', '10').set('split', 10),
+    new Map().set('partition', '10').set('partitionCount', 10),
     this.qunit
   );
 
@@ -240,10 +240,10 @@ test('load works with a double-digit single partition', function(assert) {
   assert.deepEqual(this.requiredModules, ['test-10-test']);
 });
 
-test('emit then `set-modules-queue` event when load balance option is true', function(assert) {
+test('emit then `set-modules-queue` event when browser param is passed', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,
-    new Map().set('loadBalance', true),
+    new Map().set('browser', 1),
     this.qunit
   );
 

--- a/tests/unit/qunit/testem-output-test.js
+++ b/tests/unit/qunit/testem-output-test.js
@@ -2,45 +2,44 @@ import { module, test } from 'qunit';
 import TestemOutput from 'ember-exam/test-support/-private/patch-testem-output';
 
 module('Unit | patch-testem-output', () => {
-  test('add partition number to test name when `split` is passed', function(assert) {
+  test('add partition number to test name when `partitionCount` is passed', function(assert) {
     assert.deepEqual(
       'Exam Partition 1 - test_module | test_name',
       TestemOutput.updateTestName(
-        new Map().set('split', 2),
+        new Map().set('partitionCount', 2),
         'test_module | test_name'
       )
     );
   });
 
-  test('add partition number to test name when `split` and `partition` are passed', function(assert) {
+  test('add partition number to test name when `partitionCount` and `partition` are passed', function(assert) {
     assert.deepEqual(
       'Exam Partition 2 - test_module | test_name',
       TestemOutput.updateTestName(
-        new Map().set('split', 2).set('partition', 2),
+        new Map().set('partitionCount', 2).set('partition', 2),
         'test_module | test_name'
       )
     );
   });
 
-  test('add browser number to test name when `loadBalance` and `browser` are passed', function(assert) {
+  test('add browser number to test name when `browser` is passed', function(assert) {
     assert.deepEqual(
       'Browser Id 1 - test_module | test_name',
       TestemOutput.updateTestName(
-        new Map().set('loadBalance', 2).set('browser', 1),
+        new Map().set('browser', 1),
         'test_module | test_name'
       )
     );
   });
 
-  test('add partition number, browser number to test name when `split`, `partition`, `browser`, and `loadBalance` are  passed', function(assert) {
+  test('add partition number, browser number to test name when `partitionCount`, `partition`, and `browser` are  passed', function(assert) {
     assert.deepEqual(
       'Exam Partition 2 - Browser Id 1 - test_module | test_name',
       TestemOutput.updateTestName(
         new Map()
-          .set('split', 2)
+          .set('partitionCount', 2)
           .set('partition', 2)
-          .set('browser', 1)
-          .set('loadBalance', 2),
+          .set('browser', 1),
         'test_module | test_name'
       )
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,6 +4242,17 @@ fs-extra@^0.24.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
+  integrity sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    klaw "^1.0.0"
+    path-is-absolute "^1.0.0"
+    rimraf "^2.2.8"
+
 fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
@@ -4554,7 +4565,7 @@ got@^8.0.1:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -5480,6 +5491,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+
+klaw@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
+  integrity sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
+  optionalDependencies:
+    graceful-fs "^4.1.9"
 
 lcid@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Newly Proposed Commands

This pr contains changes in command lines in ember-exam. 

With the current existing/proposed commands,
-  `--split` splits the full list of test modules into a number of partitions set by the input value, but `--split` feels lacking in meaning when looking at the command by itself.
- `parallel` is a boolean to run tests on multiple browsers and the number of browsers to invoke depending on the combination of commands: `split` or `partition`. When `parallel` is used with `load-balance` `parallel` takes a numeric value and `parallel` is to decide a number of browsers.

This confusion raises problems of  that the 'parallel' command is convoluted  the naming of some of the commands are not straight forward.

Newly proposed commands will replace `split` with `partition-count`  and a combination of `load-balance` and `parallel` with `browser-count`. `partition` remains the same as before to specify the partition to execute.

The usage of `browser-count` defaults running tests with load-balancing mode, while keeping the existing commands to run tests as it does today. The new commands tries to remove the convoluted usage, provide more meaningful names and simple usages.

## Example

1. With no parallel child processes (only one browser running a whole test suite)

| current proposed CLI | new CLI |
| ---                               |    ----   | 
ember exam | ember exam
ember exam --random | ember exam --random
ember exam --split=2 --partition=1 | Ember exam --partition-count=2 --partition=1
Ember exam --split=4 --partition=1..3 | Ember exam --partition-count=4 --partition=1..3

2. With parallel child processes and no TLB ( number of browsers varied)

Old cli | New cli | Notes
-- | -- | --
ember exam --split=3 --partition1,2 --parallel | ember exam --partition-count=3 --partition1,2 --parallel | Split tests into 3 partitions and run partition 1 and 2 with 2 browsers
ember exam --split=3 --parallel | ember exam --partition-count=3 --parallel | Split tests into 3 partitions and run partition 1 and 2 with 2 browsers

3. With parallel child processes and TLB

Old cli | New cli | Notes
-- | -- | --
ember exam --load-balance --parallel=2 | ember exam --browser-count=2 | Execute test suites with two browsers with TLB
ember exam --split=2 --partition=1 --load-balance --parallel=3 | ember exam --partition-count=2 --partition=1 --browser-count=3 | Split tests into 2 partition and run the first partition with 1 browsers with TLB
ember exam --replay-execution=[file_name.json] --replay-browser=[number] | The same as before | /

*** **The pr should come after https://github.com/ember-cli/ember-exam/pull/136 lands**