### PR TITLE
Read broweserId as a string in setReplayExecutionMap and Fix a type

### DIFF
--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -255,7 +255,7 @@ module.exports = TestCommand.extend({
         return;
       } else if (commands.get('writeExecutionFile')) {
         const browserId = getBrowserId(this.launcher.settings.test_page);
-        testemEvents.recoredFailedBrowserId(browserId);
+        testemEvents.recordFailedBrowserId(browserId);
       }
 
       browserExitHandler();
@@ -288,7 +288,7 @@ module.exports = TestCommand.extend({
     events['test-result'] = function(result) {
       if (result.failed && commands.get('writeExecutionFile')) {
         const browserId = getBrowserId(this.launcher.settings.test_page);
-        testemEvents.recoredFailedBrowserId(browserId);
+        testemEvents.recordFailedBrowserId(browserId);
       }
     };
     events['after-tests-complete'] = browserExitHandler;

--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -38,8 +38,8 @@ class TestemEvents {
     if (browserIdsToReplay && browserIdsToReplay.length > 0) {
       browserIdsToReplay.forEach(browserId => {
         browserModuleMap.set(
-          browserId,
-          executionJson.executionMapping[browserId]
+          browserId.toString(),
+          executionJson.executionMapping[browserId.toString()]
         );
       });
     } else if (executionJson.failedBrowsers.length > 0) {
@@ -52,8 +52,8 @@ class TestemEvents {
     } else {
       for (let browserId = 1; browserId <= executionJson.numberOfBrowsers; browserId++) {
         browserModuleMap.set(
-          browserId,
-          executionJson.executionMapping[browserId]
+          browserId.toString(),
+          executionJson.executionMapping[browserId.toString()]
         );
       }
     }
@@ -79,7 +79,7 @@ class TestemEvents {
       } else if (!this.stateManager.getReplayExecutionModuleQueue(browserId)) {
         // Only set the moduleQueue once, ignore repeated requests
         this.stateManager.setReplayExecutionModuleQueue(
-          replayExecutionMap.get(parseInt(browserId)),
+          replayExecutionMap.get(browserId),
           browserId
         );
       }
@@ -126,7 +126,7 @@ class TestemEvents {
    *
    * @param {number} browserId
    */
-  recoredFailedBrowserId(browserId) {
+  recordFailedBrowserId(browserId) {
     if (!this.stateManager.containsFailedBrowser(browserId)) {
       this.stateManager.addFailedBrowsers(browserId);
     }

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -402,7 +402,7 @@ describe('Acceptance | Exam Command', function() {
     });
 
     it('replay only the failed browsers defined in failedBrowsers array', function() {
-      testExecutionJson.failedBrowsers.push(1);
+      testExecutionJson.failedBrowsers.push("1");
       fixturify.writeSync(process.cwd(), {
         'test-execution-123.json': JSON.stringify(testExecutionJson)
       });
@@ -479,7 +479,7 @@ describe('Acceptance | Exam Command', function() {
           'no test execution json should be written'
         );
 
-        assertOutput(output, 'Browser Id', [2]);
+        assertOutput(output, 'Browser Id', ["2"]);
         assert.equal(
           getNumberOfTests(output),
           23,

--- a/node-tests/unit/utils/testem-events-test.js
+++ b/node-tests/unit/utils/testem-events-test.js
@@ -12,7 +12,7 @@ const testExecutionJson = {
   numberOfBrowsers: 1,
   failedBrowsers: [],
   executionMapping: {
-    1: ['path/to/testmodule', 'path/to/another/testmodule']
+    "1": ['path/to/testmodule', 'path/to/another/testmodule']
   }
 };
 
@@ -45,8 +45,8 @@ describe('TestemEvents', function() {
 
     it('ignore subsequent setModuleQueue if moduleQueue is already set for load-balance mode', function() {
       const anotherModuleQueue = ['a', 'b', 'c'];
-      this.testemEvents.setModuleQueue(1, this.moduleQueue, true, false);
-      this.testemEvents.setModuleQueue(2, anotherModuleQueue, true, false);
+      this.testemEvents.setModuleQueue("1", this.moduleQueue, true, false);
+      this.testemEvents.setModuleQueue("2", anotherModuleQueue, true, false);
 
       assert.deepEqual(
         this.testemEvents.stateManager.getTestModuleQueue(),
@@ -55,22 +55,22 @@ describe('TestemEvents', function() {
     });
 
     it('set replayExecutionModuleQueue for replay-execution mode', function() {
-      this.testemEvents.setReplayExecutionMap(testExecutionJsonPath, [1]);
-      this.testemEvents.setModuleQueue(1, this.moduleQueue, false, true);
+      this.testemEvents.setReplayExecutionMap(testExecutionJsonPath, ["1"]);
+      this.testemEvents.setModuleQueue("1", this.moduleQueue, false, true);
 
       assert.deepEqual(
-        this.testemEvents.stateManager.getReplayExecutionModuleQueue(1),
-        testExecutionJson.executionMapping[1]
+        this.testemEvents.stateManager.getReplayExecutionModuleQueue("1"),
+        testExecutionJson.executionMapping["1"]
       );
     });
 
     it('set replayExecutionModuleQueue for replay-execution mode when replay-browser is undefined', function() {
       this.testemEvents.setReplayExecutionMap(testExecutionJsonPath);
-      this.testemEvents.setModuleQueue(1, this.moduleQueue, false, true);
+      this.testemEvents.setModuleQueue("1", this.moduleQueue, false, true);
 
       assert.deepEqual(
-        this.testemEvents.stateManager.getReplayExecutionModuleQueue(1),
-        testExecutionJson.executionMapping[1]
+        this.testemEvents.stateManager.getReplayExecutionModuleQueue("1"),
+        testExecutionJson.executionMapping["1"]
       );
     });
 
@@ -149,9 +149,9 @@ describe('TestemEvents', function() {
     });
   });
 
-  describe('recoredFailedBrowserId', function() {
+  describe('recordFailedBrowserId', function() {
     it('record new browserId if test failed', function() {
-      this.testemEvents.recoredFailedBrowserId(1);
+      this.testemEvents.recordFailedBrowserId(1);
 
       assert.deepEqual(
         this.testemEvents.stateManager.getFailedBrowsers(),
@@ -161,8 +161,8 @@ describe('TestemEvents', function() {
     });
 
     it('does not record browserId that has already been recorded', function() {
-      this.testemEvents.recoredFailedBrowserId(1);
-      this.testemEvents.recoredFailedBrowserId(1);
+      this.testemEvents.recordFailedBrowserId(1);
+      this.testemEvents.recordFailedBrowserId(1);
 
       assert.deepEqual(
         this.testemEvents.stateManager.getFailedBrowsers(),


### PR DESCRIPTION
When we record a failed browser id(s) to write it in test-execution-[timestamp].json ember-exam gets a browserId by parsing a url from launcher.setting.test_page. The type of the browserId is string and it's written as a string in the json file. 

For instance, a failedBrowser key in test execution json file will look like:
```
{
  failedBrowser = ["1", "3" ]
}
```
When ember-exam sees `replay-execution` option and read a json file it generates a map which maps from a `string` browserId to a list modules. As the key is stored as a string, when a value for a key is needed to fetch the key should also be string.




