### PR TITLE
[wip] Make mocha work with ember-exam v3

### DIFF
--- a/addon-test-support/-private/ember-exam-mocha-test-loader.js
+++ b/addon-test-support/-private/ember-exam-mocha-test-loader.js
@@ -1,10 +1,12 @@
 import getUrlParams from './get-url-params';
 import splitTestModules from './split-test-modules';
-import { TestLoader } from 'ember-mocha/test-loader';
+import { describe, it } from 'mocha';
+
+// get testLoader from 'ember-qunit/test-loader' once a new version get's released
+import TestLoader from 'ember-cli-test-loader/test-support/index';
 
 /**
- * EmberExamMochaTestLoader extends ember-mocha/test-loader used by `ember test`, since it
- * overrides moduleLoadFailure() to log a test failure when a module fails to load
+ * EmberExamMochaTestLoader extends ember-cli-test-loader used by `ember test`
  * @class EmberExamMochaTestLoader
  * @extends {TestLoader}
  */
@@ -42,6 +44,20 @@ export default class EmberExamMochaTestLoader extends TestLoader {
    * Make unsee a no-op to avoid any unwanted resets
    */
   unsee() {}
+
+  /**
+   * ensure a test failure is reported if a module cannot be loaded
+   *
+   * @param {string} moduleName
+   * @param {error} error
+   */
+  moduleLoadFailure(moduleName, error) {
+    describe('TestLoader Failures', function() {
+      it(moduleName + ': could not be loaded', function() {
+        throw error;
+      });
+    });
+  }
 
   /**
    * Loads the test modules depending on the urlParam

--- a/addon-test-support/-private/get-test-loader.js
+++ b/addon-test-support/-private/get-test-loader.js
@@ -1,4 +1,19 @@
-/* globals require, requirejs */
+/* globals require */
+
+const emberQunit = 'ember-qunit';
+const emberMocha = 'ember-mocha';
+
+/**
+ * Returns the test framework being used
+ */
+export function getTestFramework() {
+  if (require.has(emberQunit)){
+    return emberQunit;
+  } else if (require.has(emberMocha)){
+    return emberMocha;
+  }
+  return;
+}
 
 /**
  * Returns ember-exam-qunit-test-loader or ember-exam-mocha-test-loader
@@ -6,13 +21,13 @@
  * @export
  * @returns {Object}
  */
-export default function getTestLoader() {
-  if (requirejs.entries['ember-qunit/test-loader']) {
+export function getTestLoader() {
+  if (require.has(emberQunit)){
     const EmberExamQUnitTestLoader = require('./ember-exam-qunit-test-loader');
     return EmberExamQUnitTestLoader['default'];
-  } else if (requirejs.entries['ember-mocha/test-loader']) {
+  } else if (require.has(emberMocha)){
     const EmberExamMochaTestLoader = require('./ember-exam-mocha-test-loader');
-    return EmberExamMochaTestLoader['default'];
+      return EmberExamMochaTestLoader['default'];
   }
 
   throw new Error(

--- a/addon-test-support/load.js
+++ b/addon-test-support/load.js
@@ -1,14 +1,29 @@
 import TestemOutput from './-private/patch-testem-output';
-import getTestLoader from './-private/get-test-loader';
+import { getTestLoader } from './-private/get-test-loader';
 
 let loaded = false;
+
+/**
+ * Equivalent to ember-qunit or ember-mocha's loadTest() except this does not create a new TestLoader instance
+ *
+ * @param {*} testLoader
+ */
+export function loadTests(testLoader) {
+  if (testLoader === undefined) {
+    throw new Error(
+      'A testLoader instance has not been created. You must call `loadEmberExam()` before calling `loadTest()`.'
+    );
+  }
+
+  testLoader.loadModules();
+}
 
 /**
  * Setup EmberExamTestLoader to enable ember exam functionalities
  *
  * @returns {*} testLoader
  */
-export default function loadEmberExam() {
+export function loadEmberExam() {
   if (loaded) {
     // eslint-disable-next-line no-console
     console.warn('Attempted to load Ember Exam more than once.');

--- a/addon-test-support/start.js
+++ b/addon-test-support/start.js
@@ -1,21 +1,7 @@
 /* globals require */
 
-import loadEmberExam from 'ember-exam/test-support/load';
-
-/**
- * Equivalent to ember-qunit or ember-mocha's loadTest() except this does not create a new TestLoader instance
- *
- * @param {*} testLoader
- */
-function loadTests(testLoader) {
-  if (testLoader === undefined) {
-    throw new Error(
-      'A testLoader instance has not been created. You must call `loadEmberExam()` before calling `loadTest()`.'
-    );
-  }
-
-  testLoader.loadModules();
-}
+import { getTestFramework } from './-private/get-test-loader';
+import { loadEmberExam, loadTests } from 'ember-exam/test-support/load';
 
 /**
  * Ember-exam's own start function to set up EmberExamTestLoader, load tests and calls start() from
@@ -24,14 +10,13 @@ function loadTests(testLoader) {
  * @param {*} qunitOptions
  */
 export default function start(qunitOptions) {
-  const framework = require.has('ember-qunit') ? 'qunit' : 'mocha';
   const modifiedOptions = qunitOptions || Object.create(null);
   modifiedOptions.loadTests = false;
 
   const testLoader = loadEmberExam();
   loadTests(testLoader);
 
-  const emberTestFramework = require(`ember-${framework}`);
+  const emberTestFramework = require(getTestFramework());
 
   if (emberTestFramework.start) {
     emberTestFramework.start(modifiedOptions);


### PR DESCRIPTION
**Problem:**
There is no `test-loader` in the latest release of ember-mocha. Hence users are seeing the following error in the browser console error:
```
Uncaught Error: Unable to find a suitable test loader. You should ensure that 
one of `ember-qunit` or `ember-mocha` are added as dependencies. at 
http://localhost:7357/assets/test-support.js, line 51528
```
reference: #238 

**Fix:**
- Change `getTestLoader()` to search for `ember-mocha` or `ember-qunit` from `require`
- Change `ember-exam-mocha-test-loader` to extend from `ember-cli-test-loader` instead of `ember-mocha/test-loader` which has not been released yet

**Other work:**
- move `loadTests` back to `load.js`

**Tests:**
- [x] Test with Ghost-admin
- [ ] Add test that tests all ember-exam features against mocha