### PR TITLE
Generate module detail json file and enable to log out a module queue statue when a browser exit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ $ ember exam --write-module-metadata-file
 $ ember exam --wmmf
 ```
 
-The `--write-module-metadata-file`, `wmmf` as an alias, allows you to generate a module metadata file after a test run. The module metadata file provides information about the test modules executed.
+The `--write-module-metadata-file`, `wmmf` as an alias, allows you to generate a module metadata file after a test run. The file provides metadata about the test modules executed.
 
 It creates a json file, `module-metadata-<timestamp>.json`, which contains an array of elements representing metadata of modules executed by sorted by ascending order:
 ```json

--- a/README.md
+++ b/README.md
@@ -140,6 +140,45 @@ The `options` should be a string matching what you would use via the CLI.
 
 _Note: This feature is not currently supported by Mocha._
 
+### Generating Module Metadata File For Test Execution
+
+```bash
+$ ember exam --write-module-metadata-file
+$ ember exam --wmmf
+```
+
+The `--write-module-metadata-file`, `wmmf` as an alias, allows you to generate a module metadata file after a test run. The module metadata file provides information about the test modules executed.
+
+It creates a json file, `module-metadata-<timestamp>.json`, which contains an array of elements representing metadata of modules executed by sorted by ascending order:
+```json
+[
+  {
+    "name": "Module-name",
+    "total": "Total number of tests in the module",
+    "runtime": "ms in Total duration to execute the module"
+  }
+]
+```
+
+and it looks something like below:
+```json
+[
+  {
+    "name": "Slowest Module",
+    "total": 12,
+    "runtime": 2159
+  },
+  {
+    "name": "Fastest Module",
+    "total": 9,
+    "runtime": 125
+  }
+]
+```
+
+_Note: This feature is not currently supported by Mocha._
+
+
 ### Splitting
 
 ```bash

--- a/addon-test-support/-private/ember-exam-qunit-test-loader.js
+++ b/addon-test-support/-private/ember-exam-qunit-test-loader.js
@@ -69,6 +69,7 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
     }
 
     super.loadModules();
+    this.setupModuleMetadataHandler();
 
     if (modulePath || filePath) {
       this._testModules = filterTestModules(
@@ -119,6 +120,17 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
   }
 
   /**
+   * setupModuleMetadataHandler() register QUnit callback to enable generating module metadata file.
+   */
+  setupModuleMetadataHandler() {
+    this._qunit.moduleDone((details) => {
+      // testem:module-done-metadata is sent to server to keep track of test module details.
+      // 'details' contains module metadata like module name, total number of assertion ran in the module, and module runtime.
+      this._testem.emit('testem:module-done-metadata', details);
+    });
+  }
+
+  /**
    * setupLoadBalanceHandlers() registers QUnit callbacks needed for the load-balance option.
    */
   setupLoadBalanceHandlers() {
@@ -166,10 +178,7 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
       return nextModuleHandler();
     });
 
-    this._qunit.moduleDone((details) => {
-      // testem:module-done-detail is sent to server to keep track of test module details.
-      // 'details' contains module metadata like module name, total number of assertion ran in the module, and module runtime.
-      this._testem.emit('testem:module-done-detail', details);
+    this._qunit.moduleDone(() => {
       return nextModuleHandler();
     });
   }

--- a/addon-test-support/-private/ember-exam-qunit-test-loader.js
+++ b/addon-test-support/-private/ember-exam-qunit-test-loader.js
@@ -167,7 +167,8 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
     });
 
     this._qunit.moduleDone((details) => {
-      // testem:module-done-detail is sent to server to keep tracking of test module details.
+      // testem:module-done-detail is sent to server to keep track of test module details.
+      // 'details' contains module metadata like module name, total number of assertion ran in the module, and module runtime.
       this._testem.emit('testem:module-done-detail', details);
       return nextModuleHandler();
     });

--- a/addon-test-support/-private/ember-exam-qunit-test-loader.js
+++ b/addon-test-support/-private/ember-exam-qunit-test-loader.js
@@ -123,10 +123,10 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
    * setupModuleMetadataHandler() register QUnit callback to enable generating module metadata file.
    */
   setupModuleMetadataHandler() {
-    this._qunit.moduleDone((details) => {
+    this._qunit.moduleDone((metadata) => {
       // testem:module-done-metadata is sent to server to keep track of test module details.
-      // 'details' contains module metadata like module name, total number of assertion ran in the module, and module runtime.
-      this._testem.emit('testem:module-done-metadata', details);
+      // 'metadata' contains module name, total number of assertion ran in the module, and module runtime.
+      this._testem.emit('testem:module-done-metadata', metadata);
     });
   }
 

--- a/addon-test-support/-private/ember-exam-qunit-test-loader.js
+++ b/addon-test-support/-private/ember-exam-qunit-test-loader.js
@@ -166,7 +166,9 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
       return nextModuleHandler();
     });
 
-    this._qunit.moduleDone(() => {
+    this._qunit.moduleDone((details) => {
+      // testem:module-done-detail is sent to server to keep tracking of test module details.
+      this._testem.emit('testem:module-done-detail', details);
       return nextModuleHandler();
     });
   }

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -248,7 +248,11 @@ module.exports = TestCommand.extend({
     let additionalEvents = this._setupAndGetBrowserSocketEvents(config);
 
     if (commandOptions.loadBalance || commandOptions.replayExecution) {
-      const loadBalancingEvents = this._getLoadBalancingBrowserSocketEvents(this.commands, this.testemEvents);
+      const loadBalancingEvents = this._getLoadBalancingBrowserSocketEvents({
+        isLoadBalance: this.commands.get('loadBalance'),
+        isReplayExecution: this.commands.get('replayExecution'),
+        isWriteExecutionFile: this.commands.get('writeExecutionFile')
+      }, this.testemEvents );
       additionalEvents = Object.assign(additionalEvents, loadBalancingEvents);
     }
 
@@ -390,25 +394,25 @@ module.exports = TestCommand.extend({
    * @param {Object} commands
    * @param {Object} testemEvents
    */
-  _getLoadBalancingBrowserSocketEvents(commands, testemEvents) {
+  _getLoadBalancingBrowserSocketEvents({ isLoadBalance, isReplayExecution, isWriteExecutionFile } , testemEvents) {
     const events = {};
     events['testem:set-modules-queue'] = function(modules, browserId) {
       testemEvents.setModuleQueue(
         browserId,
         modules,
-        commands.get('loadBalance'),
-        commands.get('replayExecution')
+        isLoadBalance,
+        isReplayExecution
       );
     };
     events['testem:next-module-request'] = function(browserId) {
       testemEvents.nextModuleResponse(
         browserId,
         this.socket,
-        commands.get('writeExecutionFile')
+        isWriteExecutionFile
       );
     };
     events['test-result'] = function(result) {
-      if (result.failed && commands.get('writeExecutionFile')) {
+      if (result.failed && isWriteExecutionFile) {
         const browserId = getBrowserId(this.launcher.settings.test_page);
         testemEvents.recordFailedBrowserId(browserId);
       }

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { addToQuery } = require('../utils/query-helper');
+const log = require('npmlog'); // eslint-disable-line node/no-extraneous-require
 const {
   combineOptionValueIntoArray,
   getBrowserId,
@@ -10,6 +11,7 @@ const TestemEvents = require('../utils/testem-events');
 const TestCommand = require('ember-cli/lib/commands/test'); // eslint-disable-line node/no-unpublished-require
 const TestServerTask = require('./task/test-server');
 const TestTask = require('./task/test');
+
 
 module.exports = TestCommand.extend({
   name: 'exam',
@@ -277,7 +279,7 @@ module.exports = TestCommand.extend({
         browserId,
         ui,
         commands.get('loadBalance'),
-        testExecutionFileName,
+        Date.now(),
         commands.get('writeExecutionFile')
       );
     };
@@ -325,6 +327,9 @@ module.exports = TestCommand.extend({
         this.socket,
         commands.get('writeExecutionFile')
       );
+    };
+    events['testem:module-done-detail'] = function(details) {
+      testemEvents.recordModuleRunDetail(details.name, details.total, details.runtime);
     };
     events['test-result'] = function(result) {
       if (result.failed && commands.get('writeExecutionFile')) {

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -278,17 +278,40 @@ module.exports = TestCommand.extend({
     const commands = this.commands;
     const testemEvents = this.testemEvents;
     const ui = this.ui;
-    const events = config.custom_browser_socket_events || {};
-    const testExecutionFileName = `test-execution-${Date.now()}.json`;
-    const browserCount = Object.keys(config.testPage).length;
-    const browserExitHandler = function() {
-      const browserId = getBrowserId(this.launcher.settings.test_page);
+
+    const browserExitHandler = function(failed = false) {
+
+      const launcherId = this.launcher.id;
+      if (!failed && commands.get('loadBalance')) {
+        try {
+          const browserId = getBrowserId(this.launcher.settings.test_page);
+          log.info(`Browser ${browserId} exiting. [ # of modules in current module queue ${testemEvents.stateManager.getTestModuleQueue().length} ]`);
+        } catch (err) {
+          const message = testemEvents.stateManager.getTestModuleQueue() === null ?
+          'testModuleQueue is not set.' :
+          `[ # of modules in current module queue ${testemEvents.stateManager.getTestModuleQueue().length} ]`;
+          if (typeof err === 'object' && err !== null) {
+            err.message = `${err.message} \n ${message}`;
+          } else {
+            throw new Error(message);
+          }
+        }
+      }
+
+      // config.testPage is undefined when parallization options are not used
+      // Set browserCount default value to 1 to allow
+      let browserCount = 1;
+      // When using multiple browsers config.testPage is an array of test page urls.
+      if (typeof config.testPage !== 'undefined') {
+        browserCount = Object.keys(config.testPage).length;
+      }
 
       testemEvents.completedBrowsersHandler(
         browserCount,
-        browserId,
+        launcherId,
         ui,
-        commands
+        commands,
+        Date.now()
       );
     };
 
@@ -310,7 +333,7 @@ module.exports = TestCommand.extend({
         testemEvents.recordFailedBrowserId(browserId);
       }
 
-      browserExitHandler.call(this);
+      browserExitHandler.call(this, true);
     };
 
     return this._getModuleMetadataAndBrowserExitSocketEvents(browserExitHandler, browserFailureHandler);

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const { addToQuery } = require('../utils/query-helper');
-const log = require('npmlog'); // eslint-disable-line node/no-extraneous-require
+// npmlog is used to write to testem server logs and `--testem-debug` enables to save the log file.
+const log = require('npmlog');
 const {
   combineOptionValueIntoArray,
   getBrowserId,
@@ -329,7 +330,13 @@ module.exports = TestCommand.extend({
       );
     };
     events['testem:module-done-detail'] = function(details) {
-      testemEvents.recordModuleRunDetail(details.name, details.total, details.runtime);
+      testemEvents.recordModuleMetaData(
+        {
+          name: details.name,
+          total: details.total,
+          runtime: details.runtime
+        }
+      );
     };
     events['test-result'] = function(result) {
       if (result.failed && commands.get('writeExecutionFile')) {

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -245,7 +245,15 @@ module.exports = TestCommand.extend({
    */
   _generateCustomConfigs(commandOptions) {
     const config = this._super._generateCustomConfigs.apply(this, arguments);
-    config.custom_browser_socket_events = this._addBrowserSocketEvents(commandOptions, config);
+    const events = config.custom_browser_socket_events || {};
+
+    this._addBrowserSocketEvents(config, events);
+
+    if (commandOptions.loadBalance || commandOptions.replayExecution) {
+      this._addLoadBalancingBrowserSocketEvents(events, this.commands, this.testemEvents);
+    }
+
+    config.custom_browser_socket_events = events;
 
     if (!commandOptions.loadBalance && !commandOptions.replayExecution && !commandOptions.parallel )
       return config;
@@ -263,13 +271,12 @@ module.exports = TestCommand.extend({
   },
 
   /**
-   * Returns an event object that enables to send and receive module metadata and load-balance if needed
+   * Add events to enable to send and receive module metadata
    *
-   * @param {*} commandOptions
-   * @param {*} config
+   * @param {Object} config
+   * @param {Object} events
    */
-  _addBrowserSocketEvents(commandOptions, config) {
-    const events = config.custom_browser_socket_events || {};
+  _addBrowserSocketEvents(config, events) {
     const commands = this.commands;
     const testemEvents = this.testemEvents;
     const ui = this.ui;
@@ -309,6 +316,17 @@ module.exports = TestCommand.extend({
       browserExitHandler.call(this);
     };
 
+    this._addCustomBrowserSocketEvents(events, browserExitHandler, browserFailureHandler);
+  },
+
+  /**
+   * Add browser socket events are needed for both with load-balance and without load-balance
+   *
+   * @param {Object} events
+   * @param {Object} browserExitHandler
+   * @param {Object} browserFailureHandler
+   */
+  _addCustomBrowserSocketEvents(events, browserExitHandler, browserFailureHandler) {
     let init = false;
 
     events['tests-start'] = function() {
@@ -318,6 +336,9 @@ module.exports = TestCommand.extend({
         init = true;
       }
     };
+
+    events['after-tests-complete'] = browserExitHandler;
+    events['disconnect'] = browserFailureHandler;
 
     events['testem:module-done-metadata'] = (details) => {
       // Ensure module detail is available
@@ -331,19 +352,6 @@ module.exports = TestCommand.extend({
         );
       }
     };
-
-    events['after-tests-complete'] = browserExitHandler;
-    events['disconnect'] = browserFailureHandler;
-
-    if (commandOptions.loadBalance || commandOptions.replayExecution) {
-      this._addLoadBalancingBrowserSocketEvents(
-        events,
-        commands,
-        testemEvents
-      );
-    }
-
-    return events;
   },
 
   /**

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -245,15 +245,14 @@ module.exports = TestCommand.extend({
    */
   _generateCustomConfigs(commandOptions) {
     const config = this._super._generateCustomConfigs.apply(this, arguments);
-    const events = config.custom_browser_socket_events || {};
-
-    this._addBrowserSocketEvents(config, events);
+    let additionalEvents = this._setupAndGetBrowserSocketEvents(config);
 
     if (commandOptions.loadBalance || commandOptions.replayExecution) {
-      this._addLoadBalancingBrowserSocketEvents(events, this.commands, this.testemEvents);
+      const loadBalancingEvents = this._getLoadBalancingBrowserSocketEvents(this.commands, this.testemEvents);
+      additionalEvents = Object.assign(additionalEvents, loadBalancingEvents);
     }
 
-    config.custom_browser_socket_events = events;
+    config.custom_browser_socket_events = Object.assign(config.custom_browser_socket_events || {}, additionalEvents);
 
     if (!commandOptions.loadBalance && !commandOptions.replayExecution && !commandOptions.parallel )
       return config;
@@ -271,12 +270,11 @@ module.exports = TestCommand.extend({
   },
 
   /**
-   * Add events to enable to send and receive module metadata
+   * Returns an event object to enable to send and receive module metadata
    *
    * @param {Object} config
-   * @param {Object} events
    */
-  _addBrowserSocketEvents(config, events) {
+  _setupAndGetBrowserSocketEvents(config) {
     const commands = this.commands;
     const testemEvents = this.testemEvents;
     const ui = this.ui;
@@ -290,8 +288,7 @@ module.exports = TestCommand.extend({
         browserCount,
         browserId,
         ui,
-        commands,
-        Date.now()
+        commands
       );
     };
 
@@ -316,17 +313,17 @@ module.exports = TestCommand.extend({
       browserExitHandler.call(this);
     };
 
-    this._addCustomBrowserSocketEvents(events, browserExitHandler, browserFailureHandler);
+    return this._getModuleMetadataAndBrowserExitSocketEvents(browserExitHandler, browserFailureHandler);
   },
 
   /**
    * Add browser socket events are needed for both with load-balance and without load-balance
    *
-   * @param {Object} events
    * @param {Object} browserExitHandler
    * @param {Object} browserFailureHandler
    */
-  _addCustomBrowserSocketEvents(events, browserExitHandler, browserFailureHandler) {
+  _getModuleMetadataAndBrowserExitSocketEvents(browserExitHandler, browserFailureHandler) {
+    const events = {};
     let init = false;
 
     events['tests-start'] = function() {
@@ -338,7 +335,14 @@ module.exports = TestCommand.extend({
     };
 
     events['after-tests-complete'] = browserExitHandler;
-    events['disconnect'] = browserFailureHandler;
+
+    events['disconnect'] = function() {
+      // when test runs without launcher (with --no-launch) process object is not avaialble.
+      // To prevent handling exiting browser browser disconnects from errors `disconnect` callback's needed to be registered.
+      if (typeof this.process === 'undefined' || this.process === null) {
+        browserFailureHandler.bind(this)();
+      }
+    }
 
     events['testem:module-done-metadata'] = (details) => {
       // Ensure module detail is available
@@ -352,17 +356,19 @@ module.exports = TestCommand.extend({
         );
       }
     };
+
+    return events;
   },
 
   /**
-   * Adds event handlers which enables load balancing.
+   * Return an event object which enables load balancing.
    * These event handlers will be registered on Testem's browserTestRunner socket instance
    *
-   * @param {Object} events
    * @param {Object} commands
    * @param {Object} testemEvents
    */
-  _addLoadBalancingBrowserSocketEvents(events, commands, testemEvents) {
+  _getLoadBalancingBrowserSocketEvents(commands, testemEvents) {
+    const events = {};
     events['testem:set-modules-queue'] = function(modules, browserId) {
       testemEvents.setModuleQueue(
         browserId,
@@ -384,5 +390,7 @@ module.exports = TestCommand.extend({
         testemEvents.recordFailedBrowserId(browserId);
       }
     };
+
+    return events;
   }
 });

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -84,6 +84,14 @@ module.exports = TestCommand.extend({
       aliases: ['wef'],
       description:
         'Allows writing a test-execution json file after running your test suite'
+    },
+    {
+      name: 'write-module-metadata-file',
+      type: Boolean,
+      default: false,
+      aliases: ['wmmf'],
+      description:
+        'Allows writing a module metadata json file after running your test suite'
     }
   ].concat(TestCommand.prototype.availableOptions),
 
@@ -237,35 +245,31 @@ module.exports = TestCommand.extend({
    */
   _generateCustomConfigs(commandOptions) {
     const config = this._super._generateCustomConfigs.apply(this, arguments);
+    config.custom_browser_socket_events = this._addBrowserSocketEvents(commandOptions, config);
 
     if (!commandOptions.loadBalance && !commandOptions.replayExecution && !commandOptions.parallel )
       return config;
 
     config.testPage = getMultipleTestPages(config, commandOptions);
 
-    if (commandOptions.loadBalance || commandOptions.replayExecution) {
-      config.custom_browser_socket_events = this._addLoadBalancingBrowserSocketEvents(
-        config
+    if (commandOptions.replayExecution) {
+      this.testemEvents.setReplayExecutionMap(
+        commandOptions.replayExecution,
+        commandOptions.replayBrowser
       );
-      if (commandOptions.replayExecution) {
-        this.testemEvents.setReplayExecutionMap(
-          commandOptions.replayExecution,
-          commandOptions.replayBrowser
-        );
-      }
     }
 
     return config;
   },
 
   /**
-   * Returns a object of event handlers which enables load balancing.
-   * These event handlers will be registered on Testem's browserTestRunner socket instance
+   * Returns an event object that enables to send and receive module metadata and load-balance if needed
    *
-   * @param {Object} config
-   * @return {Object} events
+   * @param {*} commandOptions
+   * @param {*} config
    */
-  _addLoadBalancingBrowserSocketEvents(config) {
+  _addBrowserSocketEvents(commandOptions, config) {
+    const events = config.custom_browser_socket_events || {};
     const commands = this.commands;
     const testemEvents = this.testemEvents;
     const ui = this.ui;
@@ -279,11 +283,11 @@ module.exports = TestCommand.extend({
         browserCount,
         browserId,
         ui,
-        commands.get('loadBalance'),
-        Date.now(),
-        commands.get('writeExecutionFile')
+        commands,
+        Date.now()
       );
     };
+
     const browserFailureHandler = function() {
       // browserFailureHandler is called for disconnect, processError or processExit events.
       // disconnect and processExit events is fired during global error and successful test runs.
@@ -314,6 +318,43 @@ module.exports = TestCommand.extend({
         init = true;
       }
     };
+
+    events['testem:module-done-metadata'] = (details) => {
+      // Ensure module detail is available
+      if (typeof details === 'object' && details !== null) {
+        this.testemEvents.recordModuleMetaData(
+          {
+            name: details.name,
+            total: details.total,
+            runtime: details.runtime
+          }
+        );
+      }
+    };
+
+    events['after-tests-complete'] = browserExitHandler;
+    events['disconnect'] = browserFailureHandler;
+
+    if (commandOptions.loadBalance || commandOptions.replayExecution) {
+      this._addLoadBalancingBrowserSocketEvents(
+        events,
+        commands,
+        testemEvents
+      );
+    }
+
+    return events;
+  },
+
+  /**
+   * Adds event handlers which enables load balancing.
+   * These event handlers will be registered on Testem's browserTestRunner socket instance
+   *
+   * @param {Object} events
+   * @param {Object} commands
+   * @param {Object} testemEvents
+   */
+  _addLoadBalancingBrowserSocketEvents(events, commands, testemEvents) {
     events['testem:set-modules-queue'] = function(modules, browserId) {
       testemEvents.setModuleQueue(
         browserId,
@@ -329,24 +370,11 @@ module.exports = TestCommand.extend({
         commands.get('writeExecutionFile')
       );
     };
-    events['testem:module-done-detail'] = function(details) {
-      testemEvents.recordModuleMetaData(
-        {
-          name: details.name,
-          total: details.total,
-          runtime: details.runtime
-        }
-      );
-    };
     events['test-result'] = function(result) {
       if (result.failed && commands.get('writeExecutionFile')) {
         const browserId = getBrowserId(this.launcher.settings.test_page);
         testemEvents.recordFailedBrowserId(browserId);
       }
     };
-    events['after-tests-complete'] = browserExitHandler;
-    events['disconnect'] = browserFailureHandler;
-
-    return events;
   }
 });

--- a/lib/utils/execution-state-manager.js
+++ b/lib/utils/execution-state-manager.js
@@ -13,6 +13,9 @@ class ExecutionStateManager {
     // A map of browerId to test modules executed for the current test execution.
     this._browserToModuleMap = new Map();
 
+    // An array keeping the module execution details
+    this._moduleRunDetails = [];
+
     // An array keeping the browserId of a browser with failing test
     this._failedBrowsers = [];
     this._completedBrowsers = new Map();
@@ -150,6 +153,15 @@ class ExecutionStateManager {
   }
 
   /**
+   * Returns an array of modules run details
+   *
+   * @returns {Array}
+   */
+  getModuleRunDetails() {
+    return this._moduleRunDetails;
+  }
+
+  /**
    * Pushes the moduleName into the moduleArray of browserId
    *
    * @param {string} moduleName
@@ -163,6 +175,17 @@ class ExecutionStateManager {
       browserModuleList = [moduleName];
     }
     this._browserToModuleMap.set(browserId, browserModuleList);
+  }
+
+  /**
+   * Pushes the module detail into the moduleRunDetails array
+   *
+   * @param {*} moduleName
+   * @param {*} totalAssertionNum
+   * @param {*} moduleTotalDuration
+   */
+  addModuleDoneDetailToModuleRunDetails(moduleName, totalAssertionNum, moduleTotalDuration) {
+    return this._moduleRunDetails.push({moduleName: moduleName, totalAssertionNum: totalAssertionNum, totalDuration: moduleTotalDuration});
   }
 
   /**

--- a/lib/utils/execution-state-manager.js
+++ b/lib/utils/execution-state-manager.js
@@ -14,7 +14,7 @@ class ExecutionStateManager {
     this._browserToModuleMap = new Map();
 
     // An array keeping the module execution details
-    this._moduleRunDetails = [];
+    this._moduleMetadata = [];
 
     // An array keeping the browserId of a browser with failing test
     this._failedBrowsers = [];
@@ -157,8 +157,8 @@ class ExecutionStateManager {
    *
    * @returns {Array}
    */
-  getModuleRunDetails() {
-    return this._moduleRunDetails;
+  getModuleMetadata() {
+    return this._moduleMetadata;
   }
 
   /**
@@ -178,14 +178,12 @@ class ExecutionStateManager {
   }
 
   /**
-   * Pushes the module detail into the moduleRunDetails array
+   * Pushes the module detail into the moduleMetadata array
    *
-   * @param {*} moduleName
-   * @param {*} totalAssertionNum
-   * @param {*} moduleTotalDuration
+   * @param {*} metaData
    */
-  addModuleDoneDetailToModuleRunDetails(moduleName, totalAssertionNum, moduleTotalDuration) {
-    return this._moduleRunDetails.push({moduleName: moduleName, totalAssertionNum: totalAssertionNum, totalDuration: moduleTotalDuration});
+  addMetadataToModuleMetadata(metaData) {
+    return this._moduleMetadata.push(metaData);
   }
 
   /**

--- a/lib/utils/execution-state-manager.js
+++ b/lib/utils/execution-state-manager.js
@@ -182,7 +182,7 @@ class ExecutionStateManager {
    *
    * @param {*} metaData
    */
-  addMetadataToModuleMetadata(metaData) {
+  addToModuleMetadata(metaData) {
     return this._moduleMetadata.push(metaData);
   }
 

--- a/lib/utils/file-system-helper.js
+++ b/lib/utils/file-system-helper.js
@@ -1,0 +1,19 @@
+const fs = require('fs-extra');
+
+/**
+ * Creates a file with targetJsonObject
+ *
+ * @param {string} fileName
+ * @param {Object} targetJsonObject
+ * @param {Object} option
+ */
+module.exports = function writeJsonToFile(fileName, targetJsonObject, option = {}) {
+  try {
+    fs.writeJsonSync(fileName, targetJsonObject, option);
+  } catch (err) {
+    if (typeof err === 'object' && err !== null) {
+      err.file =  err.file || fileName;
+    }
+    throw err;
+  }
+}

--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -3,25 +3,13 @@
 const fs = require('fs-extra');
 const path = require('path');
 const ExecutionStateManager = require('./execution-state-manager');
+const writeJsonToFile = require('./file-system-helper');
 
 /**
- * Creates a file with targetJsonObject
+ * Return sorted module metadata object by module runtime.
  *
- * @param {*} fileName
- * @param {*} targetJsonObject
- * @param {*} option
+ * @param {Object} moduleMetadata
  */
-function writeJsonToFile(fileName, targetJsonObject, option = {}) {
-  try {
-    fs.writeJsonSync(fileName, targetJsonObject, option);
-  } catch (err) {
-    if (typeof err === 'object' && err !== null) {
-      err.file =  err.file || fileName;
-    }
-    throw err;
-  }
-}
-
 function getSortedModuleMetaData(moduleMetadata) {
   return moduleMetadata.slice().sort((a, b) => b.runtime - a.runtime );
 }
@@ -146,7 +134,7 @@ class TestemEvents {
   /**
    * Record the module run details to the stateManager
    *
-   * @param {*} metaData
+   * @param {Object} metaData
    */
   recordModuleMetaData(metaData) {
     this.stateManager.addMetadataToModuleMetadata(metaData);
@@ -166,7 +154,7 @@ class TestemEvents {
   /**
    * Generates an object for test execution
    *
-   * @param {*} browserCount
+   * @param {number} browserCount
    */
   _generatesModuleMapJsonObject(browserCount) {
     return {

--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -137,7 +137,7 @@ class TestemEvents {
    * @param {Object} metaData
    */
   recordModuleMetaData(metaData) {
-    this.stateManager.addMetadataToModuleMetadata(metaData);
+    this.stateManager.addToModuleMetadata(metaData);
   }
 
   /**

--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -5,6 +5,28 @@ const path = require('path');
 const ExecutionStateManager = require('./execution-state-manager');
 
 /**
+ * Creates a file with targetJsonObject
+ *
+ * @param {*} fileName
+ * @param {*} targetJsonObject
+ * @param {*} option
+ */
+function writeJsonToFile(fileName, targetJsonObject, option = {}) {
+  try {
+    fs.writeJsonSync(fileName, targetJsonObject, option);
+  } catch (err) {
+    if (typeof err === 'object' && err !== null) {
+      err.file =  err.file || fileName;
+    }
+    throw err;
+  }
+}
+
+function getSortedModuleMetaData(moduleMetadata) {
+  return moduleMetadata.slice().sort((a, b) => b.runtime - a.runtime );
+}
+
+/**
  * A class to coordinate testem events to enable load-balance functionality.
  *
  * @class TestemEvents
@@ -124,12 +146,10 @@ class TestemEvents {
   /**
    * Record the module run details to the stateManager
    *
-   * @param {*} moduleName
-   * @param {*} totalAssertionNum
-   * @param {*} moduleTotalDuration
+   * @param {*} metaData
    */
-  recordModuleRunDetail(moduleName, totalAssertionNum, moduleTotalDuration) {
-    this.stateManager.addModuleDoneDetailToModuleRunDetails(moduleName, totalAssertionNum, moduleTotalDuration);
+  recordModuleMetaData(metaData) {
+    this.stateManager.addMetadataToModuleMetadata(metaData);
   }
 
   /**
@@ -164,22 +184,6 @@ class TestemEvents {
   }
 
   /**
-   * Creates a file with targetJsonObject
-   *
-   * @param {*} fileName
-   * @param {*} targetJsonObject
-   * @param {*} option
-   */
-  _generatesJsonExecutionFile(fileName, targetJsonObject, option = {}) {
-    try {
-      fs.writeJsonSync(fileName, targetJsonObject, option);
-    } catch (err) {
-      err.file =  err.file || fileName;
-      throw err;
-    }
-  }
-
-  /**
    * Keep track of the number of browsers that completed executing its tests.
    * When all browsers complete, write test-execution.json to disk and clean up the stateManager
    *
@@ -196,16 +200,16 @@ class TestemEvents {
     this.stateManager.incrementCompletedBrowsers(browserId);
     if (this.stateManager.getCompletedBrowser() === browserCount) {
       const moduleDetailFileName = path.join(this.root, `module-run-details-${currentDate}.json`);
-      const sortedModuleRunDetails = this.stateManager.getModuleRunDetails().sort((a, b) => { return b.totalDuration - a.totalDuration; });
+      const sortedModuleMetadata = getSortedModuleMetaData(this.stateManager.getModuleMetadata());
 
-      this._generatesJsonExecutionFile(moduleDetailFileName, sortedModuleRunDetails, { spaces: 2});
+      writeJsonToFile(moduleDetailFileName, sortedModuleMetadata, { spaces: 2 });
       ui.writeLine(`\nThis execution module details was recorded at ${moduleDetailFileName}`);
 
       if (writeExecutionFile && loadBalance) {
         const moduleMapJson = this._generatesModuleMapJsonObject(browserCount);
         const testExecutionPath = path.join(this.root, `test-execution-${currentDate}.json`);
 
-        this._generatesJsonExecutionFile(testExecutionPath, moduleMapJson, { spaces: 2});
+        writeJsonToFile(testExecutionPath, moduleMapJson, { spaces: 2 });
         ui.writeLine(`\nThis execution was recorded at ${testExecutionPath}`);
       }
 

--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -176,15 +176,15 @@ class TestemEvents {
    * When all browsers complete, write test-execution.json to disk and clean up the stateManager
    *
    * @param {number} browserCount
-   * @param {number} browserid
+   * @param {number} launcherId
    * @param {Object} ui
    * @param {Object} commands
    * @param {Object} currentDate
    */
-  completedBrowsersHandler(browserCount, browserId, ui, loadBalance, fileName, writeExecutionFile) {
+  completedBrowsersHandler(browserCount, launcherId, ui, commands, currentDate) {
     let browsersCompleted = false;
 
-    this.stateManager.incrementCompletedBrowsers(browserId);
+    this.stateManager.incrementCompletedBrowsers(launcherId);
     if (this.stateManager.getCompletedBrowser() === browserCount) {
       if (commands.get('writeModuleMetadataFile')) {
         const moduleDetailFileName = path.join(this.root, `module-metadata-${currentDate}.json`);

--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -122,6 +122,17 @@ class TestemEvents {
   }
 
   /**
+   * Record the module run details to the stateManager
+   *
+   * @param {*} moduleName
+   * @param {*} totalAssertionNum
+   * @param {*} moduleTotalDuration
+   */
+  recordModuleRunDetail(moduleName, totalAssertionNum, moduleTotalDuration) {
+    this.stateManager.addModuleDoneDetailToModuleRunDetails(moduleName, totalAssertionNum, moduleTotalDuration);
+  }
+
+  /**
    * Record the failed browserId to the stateManager
    *
    * @param {number} browserId
@@ -153,6 +164,22 @@ class TestemEvents {
   }
 
   /**
+   * Creates a file with targetJsonObject
+   *
+   * @param {*} fileName
+   * @param {*} targetJsonObject
+   * @param {*} option
+   */
+  _generatesJsonExecutionFile(fileName, targetJsonObject, option = {}) {
+    try {
+      fs.writeJsonSync(fileName, targetJsonObject, option);
+    } catch (err) {
+      err.file =  err.file || fileName;
+      throw err;
+    }
+  }
+
+  /**
    * Keep track of the number of browsers that completed executing its tests.
    * When all browsers complete, write test-execution.json to disk and clean up the stateManager
    *
@@ -160,7 +187,7 @@ class TestemEvents {
    * @param {number} browserid
    * @param {Object} ui
    * @param {boolean} loadBalance
-   * @param {string} fileName
+   * @param {string} currentDate
    * @param {string} writeExecutionFile
    */
   completedBrowsersHandler(browserCount, browserId, ui, loadBalance, fileName, writeExecutionFile) {
@@ -168,16 +195,18 @@ class TestemEvents {
 
     this.stateManager.incrementCompletedBrowsers(browserId);
     if (this.stateManager.getCompletedBrowser() === browserCount) {
+      const moduleDetailFileName = path.join(this.root, `module-run-details-${currentDate}.json`);
+      const sortedModuleRunDetails = this.stateManager.getModuleRunDetails().sort((a, b) => { return b.totalDuration - a.totalDuration; });
+
+      this._generatesJsonExecutionFile(moduleDetailFileName, sortedModuleRunDetails, { spaces: 2});
+      ui.writeLine(`\nThis execution module details was recorded at ${moduleDetailFileName}`);
+
       if (writeExecutionFile && loadBalance) {
         const moduleMapJson = this._generatesModuleMapJsonObject(browserCount);
-        const testExecutionPath = path.join(this.root, fileName);
-        try {
-          fs.writeJsonSync(testExecutionPath, moduleMapJson, { spaces: 2 });
-          ui.writeLine(`\nThis execution was recorded at ${fileName}`);
-        } catch (err) {
-          err.file = err.file || testExecutionPath;
-          throw err;
-        }
+        const testExecutionPath = path.join(this.root, `test-execution-${currentDate}.json`);
+
+        this._generatesJsonExecutionFile(testExecutionPath, moduleMapJson, { spaces: 2});
+        ui.writeLine(`\nThis execution was recorded at ${testExecutionPath}`);
       }
 
       // --server mode allows rerun of tests by refreshing the browser

--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -190,22 +190,23 @@ class TestemEvents {
    * @param {number} browserCount
    * @param {number} browserid
    * @param {Object} ui
-   * @param {boolean} loadBalance
-   * @param {string} currentDate
-   * @param {string} writeExecutionFile
+   * @param {Object} commands
+   * @param {Object} currentDate
    */
   completedBrowsersHandler(browserCount, browserId, ui, loadBalance, fileName, writeExecutionFile) {
     let browsersCompleted = false;
 
     this.stateManager.incrementCompletedBrowsers(browserId);
     if (this.stateManager.getCompletedBrowser() === browserCount) {
-      const moduleDetailFileName = path.join(this.root, `module-run-details-${currentDate}.json`);
-      const sortedModuleMetadata = getSortedModuleMetaData(this.stateManager.getModuleMetadata());
+      if (commands.get('writeModuleMetadataFile')) {
+        const moduleDetailFileName = path.join(this.root, `module-run-details-${currentDate}.json`);
+        const sortedModuleMetadata = getSortedModuleMetaData(this.stateManager.getModuleMetadata());
 
-      writeJsonToFile(moduleDetailFileName, sortedModuleMetadata, { spaces: 2 });
-      ui.writeLine(`\nThis execution module details was recorded at ${moduleDetailFileName}`);
+        writeJsonToFile(moduleDetailFileName, sortedModuleMetadata, { spaces: 2 });
+        ui.writeLine(`\nThis execution module details was recorded at ${moduleDetailFileName}`);
+      }
 
-      if (writeExecutionFile && loadBalance) {
+      if (commands.get('writeExecutionFile') && commands.get('loadBalance')) {
         const moduleMapJson = this._generatesModuleMapJsonObject(browserCount);
         const testExecutionPath = path.join(this.root, `test-execution-${currentDate}.json`);
 

--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -187,7 +187,7 @@ class TestemEvents {
     this.stateManager.incrementCompletedBrowsers(browserId);
     if (this.stateManager.getCompletedBrowser() === browserCount) {
       if (commands.get('writeModuleMetadataFile')) {
-        const moduleDetailFileName = path.join(this.root, `module-run-details-${currentDate}.json`);
+        const moduleDetailFileName = path.join(this.root, `module-metadata-${currentDate}.json`);
         const sortedModuleMetadata = getSortedModuleMetaData(this.stateManager.getModuleMetadata());
 
         writeJsonToFile(moduleDetailFileName, sortedModuleMetadata, { spaces: 2 });

--- a/lib/utils/tests-options-validator.js
+++ b/lib/utils/tests-options-validator.js
@@ -127,6 +127,13 @@ module.exports = class TestsOptionsValidator {
    */
   validateCommands() {
     const validatedOptions = new Map();
+    if (this.options.writeModuleMetadataFile) {
+      validatedOptions.set(
+        'writeModuleMetadataFile',
+        true
+      );
+    }
+
     if (this.options.split || this.options.partition) {
       validatedOptions.set('split', this.validateSplit());
     }

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -306,13 +306,13 @@ describe('Acceptance | Exam Command', function() {
     function assertModuleDetailJson(output) {
       let moduleRunDetailJsonPath = path.join(
         process.cwd(),
-        output.match(/module-run-details-([0-9]*).json/g)[0]
+        output.match(/module-metadata-([0-9]*).json/g)[0]
       );
+      unlinkFiles.push(moduleRunDetailJsonPath);
       assert.ok(
         fs.existsSync(moduleRunDetailJsonPath),
         'module run detail json written to root'
       );
-      unlinkFiles.push(moduleRunDetailJsonPath);
     }
 
     afterEach(() => {
@@ -475,7 +475,7 @@ describe('Acceptance | Exam Command', function() {
           'failure-dist',
           '--load-balance',
           '--parallel',
-          '1',
+          '2',
           '--write-module-metadata-file'
         ]).then(assertExpectRejection, error => {
           assert.ok(
@@ -517,7 +517,7 @@ describe('Acceptance | Exam Command', function() {
 
     afterEach(() => {
       fs.unlinkSync(path.join(process.cwd(), 'test-execution-123.json'));
-      glob.sync('module-run-details-*.json').forEach((file) => {
+      glob.sync('module-metadata-*.json').forEach((file) => {
         fs.unlinkSync(path.join(process.cwd(), file));
       });
     });

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -359,12 +359,13 @@ describe('Acceptance | Exam Command', function() {
       });
     });
 
-    it('should write module detail json after execution', function() {
+    it('should write module detail json after execution with `write-module-metadata-file`.', function() {
       return execa('ember', [
         'exam',
         '--path',
         'acceptance-dist',
         '--load-balance',
+        '--write-module-metadata-file',
         '--parallel'
       ]).then(child => {
         const output = child.stdout;
@@ -445,7 +446,7 @@ describe('Acceptance | Exam Command', function() {
         fs.removeSync(destPath);
       });
 
-      it('should write test-execution json and module-detail json when browser exits', function() {
+      it('should write test-execution json when browser exits', function() {
         return execa('ember', [
           'exam',
           '--path',
@@ -464,6 +465,26 @@ describe('Acceptance | Exam Command', function() {
             `browser exited during the test execution:\n${output}`
           );
           assertTestExecutionFailedBrowsers(output, 1);
+        });
+      });
+
+      it('should write module metadata json when browser exits', function() {
+        return execa('ember', [
+          'exam',
+          '--path',
+          'failure-dist',
+          '--load-balance',
+          '--parallel',
+          '1',
+          '--write-module-metadata-file'
+        ]).then(assertExpectRejection, error => {
+          assert.ok(
+            error.message.includes(
+              'Error: Browser exited on request from test driver'
+            ),
+            `browser exited during the test execution:\n${error.message}`
+          );
+          assertModuleDetailJson(error.message);
         });
       });
     });

--- a/node-tests/unit/utils/execution-state-manager-test.js
+++ b/node-tests/unit/utils/execution-state-manager-test.js
@@ -115,7 +115,7 @@ describe('ExecutionStateManager', function() {
         runtime: 1
       };
 
-      this.stateManager.addMetadataToModuleMetadata(moduleMetadata);
+      this.stateManager.addToModuleMetadata(moduleMetadata);
 
       assert.equal(
         this.stateManager.getModuleMetadata()[0].name,

--- a/node-tests/unit/utils/execution-state-manager-test.js
+++ b/node-tests/unit/utils/execution-state-manager-test.js
@@ -103,29 +103,31 @@ describe('ExecutionStateManager', function() {
     // test addModuleDoneDetailToModuleRunDetails
     it('returns an empty array', function() {
       assert.equal(
-        this.stateManager.getModuleRunDetails().length,
+        this.stateManager.getModuleMetadata().length,
         0
       );
     });
 
-    it('adds module detail to moduleRunDetails', function() {
-      const moduleName = 'foo';
-      const totalAssertionNum = 1;
-      const totalDuration = 1;
+    it('adds module detail to moduleMetadata', function() {
+      const moduleMetadata = {
+        name: 'foo',
+        total: 1,
+        runtime: 1
+      };
 
-      this.stateManager.addModuleDoneDetailToModuleRunDetails(moduleName, totalAssertionNum, totalDuration);
+      this.stateManager.addMetadataToModuleMetadata(moduleMetadata);
 
       assert.equal(
-        this.stateManager.getModuleRunDetails()[0].moduleName,
-        moduleName
+        this.stateManager.getModuleMetadata()[0].name,
+        moduleMetadata.name
       );
       assert.equal(
-        this.stateManager.getModuleRunDetails()[0].totalAssertionNum,
-        totalAssertionNum
+        this.stateManager.getModuleMetadata()[0].total,
+        moduleMetadata.total
       );
       assert.equal(
-        this.stateManager.getModuleRunDetails()[0].totalDuration,
-        totalDuration
+        this.stateManager.getModuleMetadata()[0].runtime,
+        moduleMetadata.runtime
       );
     })
   })

--- a/node-tests/unit/utils/execution-state-manager-test.js
+++ b/node-tests/unit/utils/execution-state-manager-test.js
@@ -131,5 +131,4 @@ describe('ExecutionStateManager', function() {
       );
     })
   })
->>>>>>> This commint adds
 });

--- a/node-tests/unit/utils/execution-state-manager-test.js
+++ b/node-tests/unit/utils/execution-state-manager-test.js
@@ -98,4 +98,36 @@ describe('ExecutionStateManager', function() {
       assert.deepEqual(this.stateManager.getCompletedBrowser(), 1);
     });
   });
+
+  describe('moduleRunDetails', function() {
+    // test addModuleDoneDetailToModuleRunDetails
+    it('returns an empty array', function() {
+      assert.equal(
+        this.stateManager.getModuleRunDetails().length,
+        0
+      );
+    });
+
+    it('adds module detail to moduleRunDetails', function() {
+      const moduleName = 'foo';
+      const totalAssertionNum = 1;
+      const totalDuration = 1;
+
+      this.stateManager.addModuleDoneDetailToModuleRunDetails(moduleName, totalAssertionNum, totalDuration);
+
+      assert.equal(
+        this.stateManager.getModuleRunDetails()[0].moduleName,
+        moduleName
+      );
+      assert.equal(
+        this.stateManager.getModuleRunDetails()[0].totalAssertionNum,
+        totalAssertionNum
+      );
+      assert.equal(
+        this.stateManager.getModuleRunDetails()[0].totalDuration,
+        totalDuration
+      );
+    })
+  })
+>>>>>>> This commint adds
 });

--- a/node-tests/unit/utils/testem-events-test.js
+++ b/node-tests/unit/utils/testem-events-test.js
@@ -226,6 +226,7 @@ describe('TestemEvents', function() {
       this.testemEvents.stateManager.addMetadataToModuleMetadata({ name: 'a', total: 1, runtime: 1});
       this.testemEvents.completedBrowsersHandler(
         1,
+        1,
         mockUi,
         new Map([
           ['loadBalance', true],
@@ -251,6 +252,7 @@ describe('TestemEvents', function() {
       this.testemEvents.stateManager.addMetadataToModuleMetadata({ name: 'baz', total: 2, runtime: 2});
 
       this.testemEvents.completedBrowsersHandler(
+        1,
         1,
         mockUi,
         new Map([

--- a/node-tests/unit/utils/testem-events-test.js
+++ b/node-tests/unit/utils/testem-events-test.js
@@ -218,7 +218,7 @@ describe('TestemEvents', function() {
     });
 
     it('should write module-run-details file and cleanup state when completedBrowsers equals browserCount, load-balance is true, and write-execution-file is false', function() {
-      this.testemEvents.stateManager.addModuleDoneDetailToModuleRunDetails('a', 1, 1);
+      this.testemEvents.stateManager.addMetadataToModuleMetadata({ name: 'a', total: 1, runtime: 1});
       this.testemEvents.completedBrowsersHandler(
         1,
         mockUi,
@@ -232,10 +232,46 @@ describe('TestemEvents', function() {
       );
 
       assert.deepEqual(JSON.parse(actual), [{
-        moduleName: 'a',
-        totalAssertionNum: 1,
-        totalDuration: 1
+        name: 'a',
+        total: 1,
+        runtime: 1
       }]);
+    });
+
+    it('should write module-run-details file with sorted by runtime', function() {
+      this.testemEvents.stateManager.addMetadataToModuleMetadata({ name: 'foo', total: 1, runtime: 1});
+      this.testemEvents.stateManager.addMetadataToModuleMetadata({ name: 'bar', total: 4, runtime: 8});
+      this.testemEvents.stateManager.addMetadataToModuleMetadata({ name: 'baz', total: 2, runtime: 2});
+
+      this.testemEvents.completedBrowsersHandler(
+        1,
+        mockUi,
+        true,
+        '0000',
+        false
+      );
+
+      const actual = fs.readFileSync(
+        path.join(fixtureDir, 'module-run-details-0000.json')
+      );
+
+      assert.deepEqual(JSON.parse(actual), [
+        {
+          name: 'bar',
+          total: 4,
+          runtime: 8
+        },
+        {
+          name: 'baz',
+          total: 2,
+          runtime: 2
+        },
+        {
+          name: 'foo',
+          total: 1,
+          runtime: 1
+        },
+      ]);
     });
 
 

--- a/node-tests/unit/utils/testem-events-test.js
+++ b/node-tests/unit/utils/testem-events-test.js
@@ -235,7 +235,7 @@ describe('TestemEvents', function() {
       );
 
       const actual = fs.readFileSync(
-        path.join(fixtureDir, 'module-run-details-0000.json')
+        path.join(fixtureDir, 'module-metadata-0000.json')
       );
 
       assert.deepEqual(JSON.parse(actual), [{
@@ -261,7 +261,7 @@ describe('TestemEvents', function() {
       );
 
       const actual = fs.readFileSync(
-        path.join(fixtureDir, 'module-run-details-0000.json')
+        path.join(fixtureDir, 'module-metadata-0000.json')
       );
 
       assert.deepEqual(JSON.parse(actual), [

--- a/node-tests/unit/utils/testem-events-test.js
+++ b/node-tests/unit/utils/testem-events-test.js
@@ -182,8 +182,11 @@ describe('TestemEvents', function() {
         2,
         1,
         mockUi,
-        true,
-        false
+        new Map([
+          ['loadBalance', true],
+          ['writeExecutionFile', false]
+        ]),
+        '0000'
       );
 
       assert.equal(
@@ -199,9 +202,11 @@ describe('TestemEvents', function() {
         1,
         1,
         mockUi,
-        true,
-        '0000',
-        true
+        new Map([
+          ['loadBalance', true],
+          ['writeExecutionFile', true]
+        ]),
+        '0000'
       );
 
       const actual = fs.readFileSync(
@@ -222,9 +227,11 @@ describe('TestemEvents', function() {
       this.testemEvents.completedBrowsersHandler(
         1,
         mockUi,
-        true,
-        '0000',
-        false
+        new Map([
+          ['loadBalance', true],
+          ['writeModuleMetadataFile', true]
+        ]),
+        '0000'
       );
 
       const actual = fs.readFileSync(
@@ -246,9 +253,11 @@ describe('TestemEvents', function() {
       this.testemEvents.completedBrowsersHandler(
         1,
         mockUi,
-        true,
-        '0000',
-        false
+        new Map([
+          ['loadBalance', true],
+          ['writeModuleMetadataFile', true]
+        ]),
+        '0000'
       );
 
       const actual = fs.readFileSync(
@@ -280,9 +289,11 @@ describe('TestemEvents', function() {
         2,
         1,
         mockUi,
-        false,
-        '0000',
-        false
+        new Map([
+          ['loadBalance', false],
+          ['writeExecutionFile', false]
+        ]),
+        '0000'
       );
 
       assert.equal(
@@ -300,9 +311,10 @@ describe('TestemEvents', function() {
         2,
         1,
         mockUi,
-        true,
-        '0000',
-        false
+        new Map([
+          ['loadBalance', true]
+        ]),
+        '0000'
       );
 
       assert.deepEqual(this.testemEvents.stateManager.getModuleMap().size, 2);
@@ -318,9 +330,10 @@ describe('TestemEvents', function() {
         1,
         1,
         mockUi,
-        true,
-        '0000',
-        false
+        new Map([
+          ['loadBalance', true]
+        ]),
+        '0000'
       );
 
       assert.deepEqual(this.testemEvents.stateManager.getModuleMap().size, 0);

--- a/node-tests/unit/utils/testem-events-test.js
+++ b/node-tests/unit/utils/testem-events-test.js
@@ -223,7 +223,7 @@ describe('TestemEvents', function() {
     });
 
     it('should write module-run-details file and cleanup state when completedBrowsers equals browserCount, load-balance is true, and write-execution-file is false', function() {
-      this.testemEvents.stateManager.addMetadataToModuleMetadata({ name: 'a', total: 1, runtime: 1});
+      this.testemEvents.stateManager.addToModuleMetadata({ name: 'a', total: 1, runtime: 1});
       this.testemEvents.completedBrowsersHandler(
         1,
         1,
@@ -247,9 +247,9 @@ describe('TestemEvents', function() {
     });
 
     it('should write module-run-details file with sorted by runtime', function() {
-      this.testemEvents.stateManager.addMetadataToModuleMetadata({ name: 'foo', total: 1, runtime: 1});
-      this.testemEvents.stateManager.addMetadataToModuleMetadata({ name: 'bar', total: 4, runtime: 8});
-      this.testemEvents.stateManager.addMetadataToModuleMetadata({ name: 'baz', total: 2, runtime: 2});
+      this.testemEvents.stateManager.addToModuleMetadata({ name: 'foo', total: 1, runtime: 1});
+      this.testemEvents.stateManager.addToModuleMetadata({ name: 'bar', total: 4, runtime: 8});
+      this.testemEvents.stateManager.addToModuleMetadata({ name: 'baz', total: 2, runtime: 2});
 
       this.testemEvents.completedBrowsersHandler(
         1,

--- a/node-tests/unit/utils/testem-events-test.js
+++ b/node-tests/unit/utils/testem-events-test.js
@@ -183,7 +183,6 @@ describe('TestemEvents', function() {
         1,
         mockUi,
         true,
-        'test-execution.json',
         false
       );
 
@@ -201,12 +200,12 @@ describe('TestemEvents', function() {
         1,
         mockUi,
         true,
-        'test-execution.json',
+        '0000',
         true
       );
 
       const actual = fs.readFileSync(
-        path.join(fixtureDir, 'test-execution.json')
+        path.join(fixtureDir, 'test-execution-0000.json')
       );
 
       assert.deepEqual(JSON.parse(actual), {
@@ -218,13 +217,35 @@ describe('TestemEvents', function() {
       });
     });
 
+    it('should write module-run-details file and cleanup state when completedBrowsers equals browserCount, load-balance is true, and write-execution-file is false', function() {
+      this.testemEvents.stateManager.addModuleDoneDetailToModuleRunDetails('a', 1, 1);
+      this.testemEvents.completedBrowsersHandler(
+        1,
+        mockUi,
+        true,
+        '0000',
+        false
+      );
+
+      const actual = fs.readFileSync(
+        path.join(fixtureDir, 'module-run-details-0000.json')
+      );
+
+      assert.deepEqual(JSON.parse(actual), [{
+        moduleName: 'a',
+        totalAssertionNum: 1,
+        totalDuration: 1
+      }]);
+    });
+
+
     it('should increment completedBrowsers when load-balance is false', function() {
       this.testemEvents.completedBrowsersHandler(
         2,
         1,
         mockUi,
         false,
-        'test-execution.json',
+        '0000',
         false
       );
 
@@ -244,7 +265,7 @@ describe('TestemEvents', function() {
         1,
         mockUi,
         true,
-        'test-execution.json',
+        '0000',
         false
       );
 
@@ -262,7 +283,7 @@ describe('TestemEvents', function() {
         1,
         mockUi,
         true,
-        'test-execution.json',
+        '0000',
         false
       );
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "execa": "^1.0.0",
     "fs-extra": "^8.0.1",
     "js-yaml": "^3.13.1",
+    "npmlog": "^4.1.2",
     "rimraf": "^2.6.2",
     "semver": "^6.3.0",
     "silent-error": "^1.1.1"

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   docsRoute(this, function() {
     this.route('randomization');
     this.route('randomization-iterator');
+    this.route('module-metadata');
     this.route('splitting');
     this.route('split-parallel');
     this.route('filtering');

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -8,6 +8,7 @@
     {{nav.section "Options"}}
     {{nav.item "Randomization" "docs.randomization"}}
     {{nav.item "Randomization Iterator" "docs.randomization-iterator"}}
+    {{nav.item "Generating Module Metadata For Test Execution" "docs.module-metadata"}}
     {{nav.item "Splitting" "docs.splitting"}}
     {{nav.item "Split Test Parallelization" "docs.split-parallel"}}
     {{nav.item "Filtering" "docs.filtering"}}

--- a/tests/dummy/app/templates/docs/module-metadata.md
+++ b/tests/dummy/app/templates/docs/module-metadata.md
@@ -1,0 +1,37 @@
+### Generating Module Metadata File For Test Execution
+
+```bash
+$ ember exam --write-module-metadata-file
+$ ember exam --wmmf
+```
+
+The `--write-module-metadata-file`, `wmmf` as an alias, allows you to generate a module metadata file after a test run. The module metadata file provides information about the test modules executed.
+
+It creates a json file, `module-metadata-<timestamp>.json`, which contains an array of elements representing metadata of modules executed by sorted by ascending order:
+```json
+[
+  {
+    "name": "Module-name",
+    "total": "Total number of tests in the module",
+    "runtime": "ms in Total duration to execute the module"
+  }
+]
+```
+
+and it looks something like below:
+```json
+[
+  {
+    "name": "Slowest Module",
+    "total": 12,
+    "runtime": 2159
+  },
+  {
+    "name": "Fastest Module",
+    "total": 9,
+    "runtime": 125
+  }
+]
+```
+
+_Note: This feature is not currently supported by Mocha._

--- a/yarn.lock
+++ b/yarn.lock
@@ -9285,7 +9285,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.0, npmlog@^4.0.2:
+npmlog@^4.0.0, npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==


### PR DESCRIPTION
This change adds
1. to generate module detail json file when running in load-balance
2. to log a module queue status when a browser exit when in load-balance mode

A load-balance mode works the best when each module duration takes a fair amount of time. For now we do not have any threshold or blocker when a long run module comes in. Having module detail json file is a first step to help setting threshold or something to make load-balance the best when comes in module duration. Additionally the module detail json file can also help investigating if any module causes a whole test suite execution last long.

Currently after test suite execution in load balance mode we do not have any information of how the test goes. Sometime we've observed that a last browser runs multiple modules (two or three) which we do not expect. Logging a length of the test module queue when a browser exits can help a bit to investigate the issue. In future I will also add a list of modules left when a browser exits to provide more informative logging.
