### PR TITLE
Introducing module-path-filter and test-file-path-filter in ember-exam

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,36 @@ ember exam --split=3 --partition=3 --parallel
 
 **Note 3**: _You must be using Testem version `1.5.0` or greater for this feature to work properly._
 
+### Filtering
+
+Ember Exam provides options to filter test suites by two types - module path and test file path.
+
+```bash
+$ ember exam --module-path-filter=<module-path>
+```
+
+The `module-path-filter` option allows you to filter module paths by a given value. Module paths are mapped by test files and they are generated during `ember build`. After the build, `tests.js` file is created and it resides under <build-directory>/assets. The file is combined of all tests in an application and it has a form of `define("<module-path>", others..`.
+
+The value for `module-path-filter` can have either string or regular expression, for instance:
+
+```bash
+# When module path value is string. This will run all modules which match with the passed value
+$ ember exam --module-path-filter='dummy/tests/helpers/module-for-acceptance'
+
+# When module path value is regex. This will run all modules which have `dummy` in it
+$ ember exam --module-path-filter='!/dummy/'
+```
+
+The `test-file-path-filter` option is to filter tests by *test file path*. The test file path is a location of the test file in a file system. You can specify `test-file-path-filter` to a location of specific test file path or you can use wildcards in paths to target multiple test files.
+
+```bash
+# This will run tests that are defined in `/my-application/tests/unit/my-test.js`
+$ ember exam --test-file-path-filter='/my-application/tests/unit/my-test.js'
+
+# This will run all test files that are under `/my-application/tests/unit/`
+$ ember exam --test-file-path-filter='/my-application/tests/unit/*.js'
+```
+
 ### Test Load Balancing
 
 ```bash

--- a/addon-test-support/-private/ember-exam-mocha-test-loader.js
+++ b/addon-test-support/-private/ember-exam-mocha-test-loader.js
@@ -1,5 +1,6 @@
 import getUrlParams from './get-url-params';
 import splitTestModules from './split-test-modules';
+import { filterTestModules} from './filter-test-modules';
 import { TestLoader } from 'ember-mocha/test-loader';
 
 /**
@@ -47,6 +48,8 @@ export default class EmberExamMochaTestLoader extends TestLoader {
    * Loads the test modules depending on the urlParam
    */
   loadModules() {
+    const modulePathFilter = this._urlParams.get('modulePathFilter');
+    const testFilePathFilter = this._urlParams.get('testFilePathFilter');
     let partitions = this._urlParams.get('partition');
     let split = parseInt(this._urlParams.get('split'), 10);
 
@@ -59,6 +62,14 @@ export default class EmberExamMochaTestLoader extends TestLoader {
     }
 
     super.loadModules();
+
+    if (modulePathFilter || testFilePathFilter) {
+      this._testModules = filterTestModules(
+        this._testModules,
+        modulePathFilter,
+        testFilePathFilter
+      );
+    }
 
     this._testModules = splitTestModules(this._testModules, split, partitions);
     this._testModules.forEach((moduleName) => {

--- a/addon-test-support/-private/ember-exam-qunit-test-loader.js
+++ b/addon-test-support/-private/ember-exam-qunit-test-loader.js
@@ -1,6 +1,7 @@
 import getUrlParams from './get-url-params';
 import splitTestModules from './split-test-modules';
 import weightTestModules from './weight-test-modules';
+import { filterTestModules } from './filter-test-modules';
 import { TestLoader } from 'ember-qunit/test-loader';
 import AsyncIterator from './async-iterator';
 import QUnit from 'qunit';
@@ -54,6 +55,8 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
   loadModules() {
     const loadBalance = this._urlParams.get('loadBalance');
     const browserId = this._urlParams.get('browser');
+    const modulePathFilter = this._urlParams.get('modulePathFilter');
+    const testFilePathFilter = this._urlParams.get('testFilePathFilter');
     let partitions = this._urlParams.get('partition');
     let split = parseInt(this._urlParams.get('split'), 10);
 
@@ -66,6 +69,14 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
     }
 
     super.loadModules();
+
+    if (modulePathFilter || testFilePathFilter) {
+      this._testModules = filterTestModules(
+        this._testModules,
+        modulePathFilter,
+        testFilePathFilter
+      );
+    }
 
     if (loadBalance && this._testem) {
       this.setupLoadBalanceHandlers();

--- a/addon-test-support/-private/filter-test-modules.js
+++ b/addon-test-support/-private/filter-test-modules.js
@@ -1,0 +1,92 @@
+// A regular expression to help parsing a string to verify regex.
+const MODULE_PATH_REGEXP = /^(!?)\/(.*)\/(i?)$/;
+const TEST_PATH_REGEX = /\/tests\/(.*?)$/;
+
+/**
+ * Return the matched test.
+ * e.g. if an input is '!/weight/' it returns an array, ['!/weight/', '!', 'weight', ''];
+ *
+ * @param {*} modulePathFilter
+ */
+function getRegexFilter(modulePathFilter) {
+  return MODULE_PATH_REGEXP.exec( modulePathFilter );
+}
+
+/**
+ * Determine if a given module path is matched with module filter with wildcard.
+ * e.g. A given moduleFilter, /tests/integration/*, matches with /tests/integration/foo and /tests/integration/bar
+ *
+ * @param {*} module
+ * @param {*} moduleFilter
+ */
+function wildcardFilter(module, moduleFilter) {
+  // Generate a regular expression to handle wildcard from path filter
+  const moduleFilterRule = ['^.*', moduleFilter.split('*').join('.*'), '$'].join('');
+  return new RegExp(moduleFilterRule).test(module);
+}
+
+/**
+ * Return a list of test modules that contain a given module path string.
+ *
+ * @param {Array<string>} modules
+ * @param {string} moduleFilter
+ */
+function stringFilter(modules, moduleFilter) {
+  return modules.filter( module => module.includes(moduleFilter) || wildcardFilter(module, moduleFilter) );
+}
+
+/**
+ * Return a list of test modules that matches with a given regular expression.
+ *
+ * @param {Array<string>} modules
+ * @param {Array<string>} modulePathRegexFilter
+ */
+function regexFilter(modules, modulePathRegexFilter) {
+  const re = new RegExp(modulePathRegexFilter[2], modulePathRegexFilter[3]);
+  const exclude = modulePathRegexFilter[1];
+
+  return modules.filter( module => !exclude && re.test(module) || exclude && !re.test(module) );
+}
+
+/**
+ * Return a module path that's mapped by a given test file path.
+ *
+ * @param {*} testFilePathFilter
+ */
+function convertFilePathToModulePath(testFilePathFilter) {
+  const filePathWithNoExtension = testFilePathFilter.replace(/\.[^/.]+$/, '');
+  const testFilePathMatch =  TEST_PATH_REGEX.exec( filePathWithNoExtension );
+  if (typeof testFilePathFilter !== 'undefined' && testFilePathMatch !== null) {
+    return testFilePathMatch[0];
+  }
+
+  return filePathWithNoExtension;
+}
+
+/**
+ * Returns a list of test modules that match with the given module path filter or test file path.
+ *
+ * @param {Array<string>} modules
+ * @param {string} modulePathFilter
+ * @param {string} testFilePathFilter
+ */
+function filterTestModules(modules, modulePathFilter, testFilePathFilter) {
+  // Generates an array with module filter value seperated by comma (,).
+  const moduleFilters = (testFilePathFilter || modulePathFilter).split(',').map( value => value.trim());
+
+  return moduleFilters.reduce((result, moduleFilter) => {
+    const modulePath = convertFilePathToModulePath(moduleFilter);
+    const modulePathRegex = getRegexFilter(modulePath);
+
+    if (modulePathRegex) {
+      return result.concat(regexFilter(modules, modulePathRegex));
+    } else {
+      return result.concat(stringFilter(modules, modulePath));
+    }
+  }, []);
+}
+
+export {
+  convertFilePathToModulePath,
+  filterTestModules
+}

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -49,6 +49,18 @@ module.exports = TestCommand.extend({
         'Randomizes your modules and tests while running your test suite.'
     },
     {
+      name: 'module-path-filter',
+      type: [String],
+      aliases: ['mpf'],
+      description: 'Filters the list of modules to only those that matches by module paths, the value accepts either string or regex.'
+    },
+    {
+      name: 'test-file-path-filter',
+      type: [String],
+      aliases: ['tfpf'],
+      description: 'Filters the list of modules to only those that matches by test file paths, the value accepts either string or regex.'
+    },
+    {
       name: 'replay-execution',
       type: String,
       default: false,
@@ -149,6 +161,22 @@ module.exports = TestCommand.extend({
           );
         }
       }
+    }
+
+    if (commandOptions.modulePathFilter) {
+      commandOptions.query = addToQuery(
+        commandOptions.query,
+        'modulePathFilter',
+        commandOptions.modulePathFilter
+      );
+    }
+
+    if (commandOptions.testFilePathFilter) {
+      commandOptions.query = addToQuery(
+        commandOptions.query,
+        'testFilePathFilter',
+        commandOptions.testFilePathFilter
+      );
     }
 
     if (commandOptions.loadBalance) {

--- a/lib/utils/tests-options-validator.js
+++ b/lib/utils/tests-options-validator.js
@@ -132,7 +132,7 @@ module.exports = class TestsOptionsValidator {
     }
 
     // The parallel option accepts a number, which can be 0
-    if (this.options.parallel !== undefined) {
+    if (typeof this.options.parallel !== 'undefined') {
       validatedOptions.set('parallel', this.validateParallel());
     }
 

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -16,7 +16,7 @@ function getNumberOfTests(str) {
   return match && parseInt(match[1], 10);
 }
 
-const TOTAL_NUM_TESTS = 48; // Total Number of tests without the global 'Ember.onerror validation tests'
+const TOTAL_NUM_TESTS = 62; // Total Number of tests without the global 'Ember.onerror validation tests'
 
 function getTotalNumberOfTests(output) {
   // In ember-qunit 3.4.0, this new check was added: https://github.com/emberjs/ember-qunit/commit/a7e93c4b4b535dae62fed992b46c00b62bfc83f4
@@ -447,7 +447,8 @@ describe('Acceptance | Exam Command', function() {
             'dummy/tests/unit/qunit/multiple-tests-test',
             'dummy/tests/unit/qunit/testem-output-test',
             'dummy/tests/unit/qunit/weight-test-modules-test',
-            'dummy/tests/unit/qunit/async-iterator-test'
+            'dummy/tests/unit/qunit/async-iterator-test',
+            'dummy/tests/unit/qunit/filter-test-modules-test'
           ]
         }
       };
@@ -538,7 +539,7 @@ describe('Acceptance | Exam Command', function() {
         assertOutput(output, 'Browser Id', ["2"]);
         assert.equal(
           getNumberOfTests(output),
-          24,
+          38,
           'ran all of the tests for browser two'
         );
       });

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -63,6 +63,12 @@ describe('ExamCommand', function() {
       });
     });
 
+    it('should set `modulePathFilter` in the query option', function() {
+      return command.run({ modulePathFilter: 'foo'}).then(function() {
+        assert.equal(called.testRunOptions.query, 'modulePathFilter=foo')
+      });
+    });
+
     it('should set `partition` in the query option with one partition', function() {
       return command.run({ split: 2, partition: [2] }).then(function() {
         assert.equal(called.testRunOptions.query, 'split=2&partition=2');

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
     this.route('randomization-iterator');
     this.route('splitting');
     this.route('split-parallel');
+    this.route('filtering');
     this.route('load-balancing');
 
     this.route('ember-try-and-ci');

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -10,6 +10,7 @@
     {{nav.item "Randomization Iterator" "docs.randomization-iterator"}}
     {{nav.item "Splitting" "docs.splitting"}}
     {{nav.item "Split Test Parallelization" "docs.split-parallel"}}
+    {{nav.item "Filtering" "docs.filtering"}}
     {{nav.item "Test Load Balancing" "docs.load-balancing"}}
 
     {{nav.section "Advanced Configuration"}}

--- a/tests/dummy/app/templates/docs/filtering.md
+++ b/tests/dummy/app/templates/docs/filtering.md
@@ -1,0 +1,29 @@
+### Filtering
+
+Ember Exam provides options to filter test suites by two types - module path and test file path.
+
+```bash
+$ ember exam --module-path-filter=<module-path>
+```
+
+The `module-path-filter` option allows you to filter module paths by a given value. Module paths are mapped by test files and they are generated during `ember build`. After the build, `tests.js` file is created and it resides under [build-directory]/assets. The file is combined of all tests in an application and it has a form of `define("<module-path>", others..`.
+
+The value for `module-path-filter` can have either string or regular expression, for instance:
+
+```bash
+# When module path value is string. This will run all modules which match with the passed value
+$ ember exam --module-path-filter='dummy/tests/helpers/module-for-acceptance'
+
+# When module path value is regex. This will run all modules which have `dummy` in it
+$ ember exam --module-path-filter='!/dummy/'
+```
+
+The `test-file-path-filter` option is to filter tests by *test file path*. The test file path is a location of the test file in a file system. You can specify `test-file-path-filter` to a location of specific test file path or you can use wildcards in paths to target multiple test files.
+
+```bash
+# This will run tests that are defined in `/my-application/tests/unit/my-test.js`
+$ ember exam --test-file-path-filter='/my-application/tests/unit/my-test.js'
+
+# This will run all test files that are under `/my-application/tests/unit/`
+$ ember exam --test-file-path-filter='/my-application/tests/unit/*.js'
+```

--- a/tests/unit/mocha/filter-test-modules-test.js
+++ b/tests/unit/mocha/filter-test-modules-test.js
@@ -1,0 +1,126 @@
+import { convertFilePathToModulePath, filterTestModules } from 'ember-exam/test-support/-private/filter-test-modules';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+
+describe('Unit | filter-test-modules', () => {
+  describe('convertFilePathToModulePath', () => {
+    it('should return an input string without file extension when the input contains file extension', () => {
+      expect(convertFilePathToModulePath('/tests/integration/foo.js')).to.equal(
+        '/tests/integration/foo'
+      );
+    });
+
+    it(`should return an input string without file extension when the input doesn't contain file extension`, () => {
+      expect(convertFilePathToModulePath('/tests/integration/foo')).to.equal(
+        '/tests/integration/foo'
+      );
+    });
+
+    it('should return an input string after `tests` when the input is a full test file path', () => {
+      expect(convertFilePathToModulePath('dummy/tests/integration/foo.js')).to.equal(
+        '/tests/integration/foo'
+      );
+    });
+  });
+
+  describe('modulePathFilter', function() {
+    beforeEach(function() {
+      this.modules = [
+        'foo-test',
+        'foo-test.jshint',
+        'bar-test',
+        'bar-test.jshint',
+      ];
+    });
+
+    afterEach(function() {
+      this.modules = [];
+    });
+
+    it('should return a list of jshint tests', () => {
+      expect(filterTestModules(this.modules, 'jshint')).to.deep.equal([
+        'foo-test.jshint',
+        'bar-test.jshint'
+      ]);
+    });
+
+    it('should return an empty list when there is no match', () => {
+      expect(filterTestModules(this.modules, 'no-match')).to.deep.equal([]);
+    });
+
+    it('should return a list of tests matched with a regular expression', () => {
+      expect(filterTestModules(this.modules, '/jshint/')).to.deep.equal([
+        'foo-test.jshint',
+        'bar-test.jshint'
+      ]);
+    });
+
+    it('should return a list of tests matched with a regular expression that excluses jshint', () => {
+      expect(filterTestModules(this.modules, '!/jshint/')).to.deep.equal([
+        'foo-test',
+        'bar-test'
+      ]);
+    });
+
+    it('should return a list of tests matches with a list of string options', () => {
+      expect(filterTestModules(this.modules, 'foo, bar')).to.deep.equal([
+        'foo-test',
+        'foo-test.jshint',
+        'bar-test',
+        'bar-test.jshint'
+      ]);
+    });
+  });
+
+  describe('testFilePathFilter', function() {
+    beforeEach(function() {
+      this.modules = [
+        'dummy/tests/integration/foo-test',
+        'dummy/tests/unit/foo-test',
+        'dummy/tests/unit/bar-test'
+      ];
+    });
+
+    afterEach(function() {
+      this.modules = [];
+    });
+
+    it('should return a test module matches with full test file path', () => {
+      expect(filterTestModules(this.modules, null, 'app/tests/integration/foo-test.js')).to.deep.equal([
+        'dummy/tests/integration/foo-test'
+      ]);
+    });
+
+    it('should return a test module matches with relative test file path', () => {
+      expect(filterTestModules(this.modules, null, '/tests/unit/foo-test')).to.deep.equal([
+        'dummy/tests/unit/foo-test'
+      ]);
+    });
+
+    it('should return a test module matched with test file path with wildcard', () => {
+      expect(filterTestModules(this.modules, null, '/unit/*')).to.deep.equal([
+        'dummy/tests/unit/foo-test',
+        'dummy/tests/unit/bar-test'
+      ]);
+    });
+
+    it('should return a test module matched with test file path with wildcard', () => {
+      expect(filterTestModules(this.modules, null, '/tests/*/foo*')).to.deep.equal([
+        'dummy/tests/integration/foo-test',
+        'dummy/tests/unit/foo-test'
+      ]);
+    });
+
+    it('should return a list of tests matched with a regular expression', () => {
+      expect(filterTestModules(this.modules, null, 'no-match')).to.deep.equal([
+      ]);
+    });
+
+    it('should return a list of tests matches with a list of string options', () => {
+      expect(filterTestModules(this.modules, null, '/tests/integration/*, dummy/tests/unit/foo-test')).to.deep.equal([
+        'dummy/tests/integration/foo-test',
+        'dummy/tests/unit/foo-test'
+      ]);
+    });
+  });
+});

--- a/tests/unit/qunit/filter-test-modules-test.js
+++ b/tests/unit/qunit/filter-test-modules-test.js
@@ -1,0 +1,153 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { convertFilePathToModulePath, filterTestModules } from 'ember-exam/test-support/-private/filter-test-modules';
+
+module('Unit | filter-test-modules', function(hooks) {
+  setupTest(hooks);
+
+  module('covertFilePathToModulePath', function(hooks) {
+    setupTest(hooks);
+
+    test('should return an input string without file extension when the input contains file extension', function(assert) {
+      assert.equal(convertFilePathToModulePath('/tests/integration/foo.js'), '/tests/integration/foo');
+    });
+
+    test(`should return an input string without file extension when the input doesn't contain file extension`, function(assert) {
+      assert.equal(convertFilePathToModulePath('/tests/integration/foo'), '/tests/integration/foo');
+    });
+
+    test('should return an input string after `tests` when the input is a full test file path', function(assert) {
+      assert.equal(convertFilePathToModulePath('dummy/tests/integration/foo.js'), '/tests/integration/foo');
+    });
+  }),
+
+  module('modulePathFilter', function(hooks) {
+    setupTest(hooks);
+    hooks.beforeEach(function() {
+      this.modules = [
+        'foo-test',
+        'foo-test.jshint',
+        'bar-test',
+        'bar-test.jshint',
+      ];
+    });
+
+    hooks.afterEach(function() {
+      this.modules = [];
+    });
+
+    test('should return a list of jshint tests', function(assert) {
+      assert.deepEqual(
+        [
+          'foo-test.jshint',
+          'bar-test.jshint'
+        ],
+        filterTestModules(this.modules, 'jshint')
+      );
+    });
+
+    test('should return an empty list when there is no match', function(assert) {
+      assert.deepEqual(
+        [], filterTestModules(this.modules, 'no-match')
+      );
+    });
+
+    test('should return a list of tests matched with a regular expression', function(assert) {
+      assert.deepEqual(
+        [
+          'foo-test.jshint',
+          'bar-test.jshint'
+        ],
+        filterTestModules(this.modules, '/jshint/')
+      );
+    });
+
+    test('should return a list of tests matched with a regular expression that excluse jshint', function(assert) {
+      assert.deepEqual(
+        [
+          'foo-test',
+          'bar-test'
+        ], filterTestModules(this.modules, '!/jshint/')
+      );
+    });
+
+    test('should return a list of tests matches with a list of string options', function(assert) {
+      assert.deepEqual(
+        [
+          'foo-test',
+          'foo-test.jshint',
+          'bar-test',
+          'bar-test.jshint'
+        ], filterTestModules(this.modules, 'foo, bar')
+      );
+    });
+  }),
+
+  module('testFilePathFilter', function(hooks) {
+    setupTest(hooks);
+    hooks.beforeEach(function() {
+      this.modules = [
+        'dummy/tests/integration/foo-test',
+        'dummy/tests/unit/foo-test',
+        'dummy/tests/unit/bar-test'
+      ];
+    });
+
+    hooks.afterEach(function() {
+      this.modules = [];
+    });
+
+    test('should return a test module matched with full test file path', function(assert) {
+      assert.deepEqual(
+        [
+          'dummy/tests/integration/foo-test',
+        ],
+        filterTestModules(this.modules, null, 'app/tests/integration/foo-test.js')
+      );
+    });
+
+    test('should return a test module matched with relative test file path', function(assert) {
+      assert.deepEqual(
+        [
+          'dummy/tests/unit/foo-test'
+        ],
+        filterTestModules(this.modules, null, '/unit/foo-test')
+      );
+    });
+
+    test('should return a test module matched with test file path with wildcard', function(assert) {
+      assert.deepEqual(
+        [
+          'dummy/tests/unit/foo-test',
+          'dummy/tests/unit/bar-test'
+        ],
+        filterTestModules(this.modules, null, '/unit/*')
+      );
+    });
+
+    test('should return a test module matched with test file path with wildcard', function(assert) {
+      assert.deepEqual(
+        [
+          'dummy/tests/integration/foo-test',
+          'dummy/tests/unit/foo-test'
+        ],
+        filterTestModules(this.modules, null, '/tests/*/foo*')
+      );
+    });
+
+    test('should return an empty list when there is no match', function(assert) {
+      assert.deepEqual(
+        [], filterTestModules(this.modules, null, 'no-match')
+      );
+    });
+
+    test('should return a list of tests matches with a list of string options', function(assert) {
+      assert.deepEqual(
+        [
+          'dummy/tests/integration/foo-test',
+          'dummy/tests/unit/foo-test'
+        ], filterTestModules(this.modules, null, '/tests/integration/*, dummy/tests/unit/foo-test')
+      );
+    });
+  });
+});


### PR DESCRIPTION
ember-test provides `filter` and `modules` to allow executing a subset of the whole test suite. The problem of current provided options is that the filtering is processed after loading a test module, which means that the filtering is done in QUnit level after requiring a module. This results requiring all the test modules in the test suite even though a subset of the tests is targeted to execute.

`module-path-filter` and `test-file-path-filter` option provide to allow running a targeted test modules that are matched with a given module path string and it only loads/requires the targeted test modules which could impact reducing test loading time.
