### PR TITLE
Allow graceful exit when async iterator fails to get a module.

### DIFF
--- a/addon-test-support/-private/ember-exam-qunit-test-loader.js
+++ b/addon-test-support/-private/ember-exam-qunit-test-loader.js
@@ -116,8 +116,9 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
     const nextModuleAsyncIterator = new AsyncIterator(this._testem, {
       request: 'testem:next-module-request',
       response: 'testem:next-module-response',
-      timeout: getUrlParams().get('asyncTimeout'),
-      browserId: getUrlParams().get('browser')
+      timeout: this._urlParams.get('asyncTimeout'),
+      browserId: this._urlParams.get('browser'),
+      emberExamExitOnError: this._urlParams.get('_emberExamExitOnError'),
     });
 
     const nextModuleHandler = () => {

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -16,7 +16,7 @@ function getNumberOfTests(str) {
   return match && parseInt(match[1], 10);
 }
 
-const TOTAL_NUM_TESTS = 47; // Total Number of tests without the global 'Ember.onerror validation tests'
+const TOTAL_NUM_TESTS = 48; // Total Number of tests without the global 'Ember.onerror validation tests'
 
 function getTotalNumberOfTests(output) {
   // In ember-qunit 3.4.0, this new check was added: https://github.com/emberjs/ember-qunit/commit/a7e93c4b4b535dae62fed992b46c00b62bfc83f4
@@ -538,7 +538,7 @@ describe('Acceptance | Exam Command', function() {
         assertOutput(output, 'Browser Id', ["2"]);
         assert.equal(
           getNumberOfTests(output),
-          23,
+          24,
           'ran all of the tests for browser two'
         );
       });

--- a/tests/unit/qunit/async-iterator-test.js
+++ b/tests/unit/qunit/async-iterator-test.js
@@ -146,21 +146,35 @@ test('should dispose after iteration.', function(assert) {
     });
 });
 
-test('should throw a timout error if request is not handled within 2s', function(assert) {
+test('should resolve with iterator finishing if request is not handled within 2s', function(assert) {
   assert.expect(1);
-  const done = assert.async();
   const iteratorOfPromises = new AsyncIterator(this.testem, {
     request: 'next-module-request',
     response: 'next-module-response',
     timeout: 2
   });
 
-  iteratorOfPromises.next().catch(err => {
+  return iteratorOfPromises.next().then(res => {
+    assert.deepEqual(res.done, true);
+  });
+});
+
+test('should resolve a timeout error if request is not handled within 2s when emberExamExitOnError is true', function(assert) {
+  assert.expect(1);
+  const iteratorOfPromises = new AsyncIterator(this.testem, {
+    request: 'next-module-request',
+    response: 'next-module-response',
+    timeout: 2,
+    emberExamExitOnError: true,
+  });
+
+  return iteratorOfPromises.next().then(() => {
+    assert.ok(false, 'Promise should not resolve, expecting reject');
+  },err => {
     assert.deepEqual(
       err.message,
       'EmberExam: Promise timed out after 2 s while waiting for response for next-module-request'
     );
-    done();
   });
 });
 


### PR DESCRIPTION
Allow graceful exit during load-balance mode if async iterator fails to get a module.

`--load-balance` mode shouldn't cause a test execution to fail. If it cannot get the next test module, allow other browsers to share the load.

If a hard exit is needed, add `emberExamExitOnError=true` to the url.

***TODO:***
- [x] Add tests