### PR TITLE
Change option names (module-path-filter and test-file-path-filter) and Enable to execute unique test modules after filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,29 +199,29 @@ ember exam --split=3 --partition=3 --parallel
 Ember Exam provides options to filter test suites by two types - module path and test file path.
 
 ```bash
-$ ember exam --module-path-filter=<module-path>
+$ ember exam --module-path=<module-path>
 ```
 
-The `module-path-filter` option allows you to filter module paths by a given value. Module paths are mapped by test files and they are generated during `ember build`. After the build, `tests.js` file is created and it resides under <build-directory>/assets. The file is combined of all tests in an application and it has a form of `define("<module-path>", others..`.
+The `module-path` option allows you to filter module paths by a given value. Module paths are mapped by test files and they are generated during `ember build`. After the build, `tests.js` file is created and it resides under <build-directory>/assets. The file is combined of all tests in an application and it has a form of `define("<module-path>", others..`.
 
-The value for `module-path-filter` can have either string or regular expression, for instance:
+The value for `module-path` can have either string or regular expression, for instance:
 
 ```bash
 # When module path value is string. This will run all modules which match with the passed value
-$ ember exam --module-path-filter='dummy/tests/helpers/module-for-acceptance'
+$ ember exam --module-path='dummy/tests/helpers/module-for-acceptance'
 
 # When module path value is regex. This will run all modules which have `dummy` in it
-$ ember exam --module-path-filter='!/dummy/'
+$ ember exam --module-path='!/dummy/'
 ```
 
-The `test-file-path-filter` option is to filter tests by *test file path*. The test file path is a location of the test file in a file system. You can specify `test-file-path-filter` to a location of specific test file path or you can use wildcards in paths to target multiple test files.
+The `file-path` option is to filter tests by *test file path*. The test file path is a location of the test file in a file system. You can specify `file-path` to a location of specific test file path or you can use wildcards in paths to target multiple test files.
 
 ```bash
 # This will run tests that are defined in `/my-application/tests/unit/my-test.js`
-$ ember exam --test-file-path-filter='/my-application/tests/unit/my-test.js'
+$ ember exam --file-path='/my-application/tests/unit/my-test.js'
 
 # This will run all test files that are under `/my-application/tests/unit/`
-$ ember exam --test-file-path-filter='/my-application/tests/unit/*.js'
+$ ember exam --file-path='/my-application/tests/unit/*.js'
 ```
 
 ### Test Load Balancing

--- a/addon-test-support/-private/ember-exam-mocha-test-loader.js
+++ b/addon-test-support/-private/ember-exam-mocha-test-loader.js
@@ -48,8 +48,8 @@ export default class EmberExamMochaTestLoader extends TestLoader {
    * Loads the test modules depending on the urlParam
    */
   loadModules() {
-    const modulePathFilter = this._urlParams.get('modulePathFilter');
-    const testFilePathFilter = this._urlParams.get('testFilePathFilter');
+    const modulePath = this._urlParams.get('modulePath');
+    const filePath = this._urlParams.get('filePath');
     let partitions = this._urlParams.get('partition');
     let split = parseInt(this._urlParams.get('split'), 10);
 
@@ -63,11 +63,11 @@ export default class EmberExamMochaTestLoader extends TestLoader {
 
     super.loadModules();
 
-    if (modulePathFilter || testFilePathFilter) {
+    if (modulePath || filePath) {
       this._testModules = filterTestModules(
         this._testModules,
-        modulePathFilter,
-        testFilePathFilter
+        modulePath,
+        filePath
       );
     }
 

--- a/addon-test-support/-private/ember-exam-qunit-test-loader.js
+++ b/addon-test-support/-private/ember-exam-qunit-test-loader.js
@@ -55,8 +55,8 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
   loadModules() {
     const loadBalance = this._urlParams.get('loadBalance');
     const browserId = this._urlParams.get('browser');
-    const modulePathFilter = this._urlParams.get('modulePathFilter');
-    const testFilePathFilter = this._urlParams.get('testFilePathFilter');
+    const modulePath = this._urlParams.get('modulePath');
+    const filePath = this._urlParams.get('filePath');
     let partitions = this._urlParams.get('partition');
     let split = parseInt(this._urlParams.get('split'), 10);
 
@@ -70,11 +70,11 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
 
     super.loadModules();
 
-    if (modulePathFilter || testFilePathFilter) {
+    if (modulePath || filePath) {
       this._testModules = filterTestModules(
         this._testModules,
-        modulePathFilter,
-        testFilePathFilter
+        modulePath,
+        filePath
       );
     }
 

--- a/addon-test-support/-private/filter-test-modules.js
+++ b/addon-test-support/-private/filter-test-modules.js
@@ -6,10 +6,10 @@ const TEST_PATH_REGEX = /\/tests\/(.*?)$/;
  * Return the matched test.
  * e.g. if an input is '!/weight/' it returns an array, ['!/weight/', '!', 'weight', ''];
  *
- * @param {*} modulePathFilter
+ * @param {*} modulePath
  */
-function getRegexFilter(modulePathFilter) {
-  return MODULE_PATH_REGEXP.exec( modulePathFilter );
+function getRegexFilter(modulePath) {
+  return MODULE_PATH_REGEXP.exec( modulePath );
 }
 
 /**
@@ -51,12 +51,12 @@ function regexFilter(modules, modulePathRegexFilter) {
 /**
  * Return a module path that's mapped by a given test file path.
  *
- * @param {*} testFilePathFilter
+ * @param {*} filePath
  */
-function convertFilePathToModulePath(testFilePathFilter) {
-  const filePathWithNoExtension = testFilePathFilter.replace(/\.[^/.]+$/, '');
+function convertFilePathToModulePath(filePath) {
+  const filePathWithNoExtension = filePath.replace(/\.[^/.]+$/, '');
   const testFilePathMatch =  TEST_PATH_REGEX.exec( filePathWithNoExtension );
-  if (typeof testFilePathFilter !== 'undefined' && testFilePathMatch !== null) {
+  if (typeof filePath !== 'undefined' && testFilePathMatch !== null) {
     return testFilePathMatch[0];
   }
 
@@ -67,21 +67,21 @@ function convertFilePathToModulePath(testFilePathFilter) {
  * Returns a list of test modules that match with the given module path filter or test file path.
  *
  * @param {Array<string>} modules
- * @param {string} modulePathFilter
- * @param {string} testFilePathFilter
+ * @param {string} modulePath
+ * @param {string} filePath
  */
-function filterTestModules(modules, modulePathFilter, testFilePathFilter) {
+function filterTestModules(modules, modulePath, filePath) {
   // Generates an array with module filter value seperated by comma (,).
-  const moduleFilters = (testFilePathFilter || modulePathFilter).split(',').map( value => value.trim());
+  const moduleFilters = (filePath || modulePath).split(',').map( value => value.trim());
 
   return moduleFilters.reduce((result, moduleFilter) => {
     const modulePath = convertFilePathToModulePath(moduleFilter);
     const modulePathRegex = getRegexFilter(modulePath);
 
     if (modulePathRegex) {
-      return result.concat(regexFilter(modules, modulePathRegex));
+      return result.concat(regexFilter(modules, modulePathRegex).filter( module => result.indexOf(module) === -1 ));
     } else {
-      return result.concat(stringFilter(modules, modulePath));
+      return result.concat(stringFilter(modules, modulePath).filter( module => result.indexOf(module) === -1 ));
     }
   }, []);
 }

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -49,15 +49,15 @@ module.exports = TestCommand.extend({
         'Randomizes your modules and tests while running your test suite.'
     },
     {
-      name: 'module-path-filter',
+      name: 'module-path',
       type: [String],
-      aliases: ['mpf'],
+      aliases: ['mp'],
       description: 'Filters the list of modules to only those that matches by module paths, the value accepts either string or regex.'
     },
     {
-      name: 'test-file-path-filter',
+      name: 'file-path',
       type: [String],
-      aliases: ['tfpf'],
+      aliases: ['fp'],
       description: 'Filters the list of modules to only those that matches by test file paths, the value accepts either string or regex.'
     },
     {
@@ -163,19 +163,19 @@ module.exports = TestCommand.extend({
       }
     }
 
-    if (commandOptions.modulePathFilter) {
+    if (commandOptions.modulePath) {
       commandOptions.query = addToQuery(
         commandOptions.query,
-        'modulePathFilter',
-        commandOptions.modulePathFilter
+        'modulePath',
+        commandOptions.modulePath
       );
     }
 
-    if (commandOptions.testFilePathFilter) {
+    if (commandOptions.filePath) {
       commandOptions.query = addToQuery(
         commandOptions.query,
-        'testFilePathFilter',
-        commandOptions.testFilePathFilter
+        'filePath',
+        commandOptions.filePath
       );
     }
 

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -16,7 +16,7 @@ function getNumberOfTests(str) {
   return match && parseInt(match[1], 10);
 }
 
-const TOTAL_NUM_TESTS = 62; // Total Number of tests without the global 'Ember.onerror validation tests'
+const TOTAL_NUM_TESTS = 64; // Total Number of tests without the global 'Ember.onerror validation tests'
 
 function getTotalNumberOfTests(output) {
   // In ember-qunit 3.4.0, this new check was added: https://github.com/emberjs/ember-qunit/commit/a7e93c4b4b535dae62fed992b46c00b62bfc83f4
@@ -539,7 +539,7 @@ describe('Acceptance | Exam Command', function() {
         assertOutput(output, 'Browser Id', ["2"]);
         assert.equal(
           getNumberOfTests(output),
-          38,
+          40,
           'ran all of the tests for browser two'
         );
       });

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -63,9 +63,9 @@ describe('ExamCommand', function() {
       });
     });
 
-    it('should set `modulePathFilter` in the query option', function() {
-      return command.run({ modulePathFilter: 'foo'}).then(function() {
-        assert.equal(called.testRunOptions.query, 'modulePathFilter=foo')
+    it('should set `modulePath` in the query option', function() {
+      return command.run({ modulePath: 'foo'}).then(function() {
+        assert.equal(called.testRunOptions.query, 'modulePath=foo')
       });
     });
 

--- a/tests/dummy/app/templates/docs/filtering.md
+++ b/tests/dummy/app/templates/docs/filtering.md
@@ -3,27 +3,27 @@
 Ember Exam provides options to filter test suites by two types - module path and test file path.
 
 ```bash
-$ ember exam --module-path-filter=<module-path>
+$ ember exam --module-path=<module-path>
 ```
 
-The `module-path-filter` option allows you to filter module paths by a given value. Module paths are mapped by test files and they are generated during `ember build`. After the build, `tests.js` file is created and it resides under [build-directory]/assets. The file is combined of all tests in an application and it has a form of `define("<module-path>", others..`.
+The `module-path` option allows you to filter module paths by a given value. Module paths are mapped by test files and they are generated during `ember build`. After the build, `tests.js` file is created and it resides under [build-directory]/assets. The file is combined of all tests in an application and it has a form of `define("<module-path>", others..`.
 
-The value for `module-path-filter` can have either string or regular expression, for instance:
+The value for `module-path` can have either string or regular expression, for instance:
 
 ```bash
 # When module path value is string. This will run all modules which match with the passed value
-$ ember exam --module-path-filter='dummy/tests/helpers/module-for-acceptance'
+$ ember exam --module-path='dummy/tests/helpers/module-for-acceptance'
 
 # When module path value is regex. This will run all modules which have `dummy` in it
-$ ember exam --module-path-filter='!/dummy/'
+$ ember exam --module-path='!/dummy/'
 ```
 
-The `test-file-path-filter` option is to filter tests by *test file path*. The test file path is a location of the test file in a file system. You can specify `test-file-path-filter` to a location of specific test file path or you can use wildcards in paths to target multiple test files.
+The `file-path` option is to filter tests by *test file path*. The test file path is a location of the test file in a file system. You can specify `file-path` to a location of specific test file path or you can use wildcards in paths to target multiple test files.
 
 ```bash
 # This will run tests that are defined in `/my-application/tests/unit/my-test.js`
-$ ember exam --test-file-path-filter='/my-application/tests/unit/my-test.js'
+$ ember exam --file-path='/my-application/tests/unit/my-test.js'
 
 # This will run all test files that are under `/my-application/tests/unit/`
-$ ember exam --test-file-path-filter='/my-application/tests/unit/*.js'
+$ ember exam --file-path='/my-application/tests/unit/*.js'
 ```

--- a/tests/unit/mocha/filter-test-modules-test.js
+++ b/tests/unit/mocha/filter-test-modules-test.js
@@ -23,7 +23,7 @@ describe('Unit | filter-test-modules', () => {
     });
   });
 
-  describe('modulePathFilter', function() {
+  describe('modulePath', function() {
     beforeEach(function() {
       this.modules = [
         'foo-test',
@@ -70,9 +70,16 @@ describe('Unit | filter-test-modules', () => {
         'bar-test.jshint'
       ]);
     });
+
+    it('should return a list of unique tests matches when options are repeated', () => {
+      expect(filterTestModules(this.modules, 'foo, foo')).to.deep.equal([
+        'foo-test',
+        'foo-test.jshint'
+      ]);
+    });
   });
 
-  describe('testFilePathFilter', function() {
+  describe('filePath', function() {
     beforeEach(function() {
       this.modules = [
         'dummy/tests/integration/foo-test',
@@ -119,6 +126,13 @@ describe('Unit | filter-test-modules', () => {
     it('should return a list of tests matches with a list of string options', () => {
       expect(filterTestModules(this.modules, null, '/tests/integration/*, dummy/tests/unit/foo-test')).to.deep.equal([
         'dummy/tests/integration/foo-test',
+        'dummy/tests/unit/foo-test'
+      ]);
+    });
+
+    it('should return a list of unique tests matches when options are repeated', () => {
+      expect(filterTestModules(this.modules, null, 'app/tests/unit/bar-test.js, /tests/unit/*')).to.deep.equal([
+        'dummy/tests/unit/bar-test',
         'dummy/tests/unit/foo-test'
       ]);
     });

--- a/tests/unit/qunit/filter-test-modules-test.js
+++ b/tests/unit/qunit/filter-test-modules-test.js
@@ -21,7 +21,7 @@ module('Unit | filter-test-modules', function(hooks) {
     });
   }),
 
-  module('modulePathFilter', function(hooks) {
+  module('modulePath', function(hooks) {
     setupTest(hooks);
     hooks.beforeEach(function() {
       this.modules = [
@@ -81,9 +81,18 @@ module('Unit | filter-test-modules', function(hooks) {
         ], filterTestModules(this.modules, 'foo, bar')
       );
     });
+
+    test('should return a list of unique tests matches when options are repeated', function(assert) {
+      assert.deepEqual(
+        [
+          'foo-test',
+          'foo-test.jshint'
+        ], filterTestModules(this.modules, 'foo, foo')
+      );
+    });
   }),
 
-  module('testFilePathFilter', function(hooks) {
+  module('filePath', function(hooks) {
     setupTest(hooks);
     hooks.beforeEach(function() {
       this.modules = [
@@ -147,6 +156,15 @@ module('Unit | filter-test-modules', function(hooks) {
           'dummy/tests/integration/foo-test',
           'dummy/tests/unit/foo-test'
         ], filterTestModules(this.modules, null, '/tests/integration/*, dummy/tests/unit/foo-test')
+      );
+    });
+
+    test('should return a list of unique tests matches when options are repeated', function(assert) {
+      assert.deepEqual(
+        [
+          'dummy/tests/unit/bar-test',
+          'dummy/tests/unit/foo-test'
+        ], filterTestModules(this.modules, null, 'app/tests/unit/bar-test.js, /tests/unit/*')
       );
     });
   });


### PR DESCRIPTION
1. Change option names to simplify:
- module-path-filter to module-path
- test-file-path-filter to file-path
2. Enable to execute unique test modules after filtering.
e.g. ember exam --file-path='foo/tests/unit/foo.js, /tests/unit/foo.js' 
it executes `foo/tests/unit/foo.js` file once