### PR TITLE
Throw an error when there are no matching tests with a given input by `file-path` and `module-path`

### DIFF
--- a/addon-test-support/-private/filter-test-modules.js
+++ b/addon-test-support/-private/filter-test-modules.js
@@ -74,7 +74,7 @@ function filterTestModules(modules, modulePath, filePath) {
   // Generates an array with module filter value seperated by comma (,).
   const moduleFilters = (filePath || modulePath).split(',').map( value => value.trim());
 
-  return moduleFilters.reduce((result, moduleFilter) => {
+  const filteredTestModules = moduleFilters.reduce((result, moduleFilter) => {
     const modulePath = convertFilePathToModulePath(moduleFilter);
     const modulePathRegex = getRegexFilter(modulePath);
 
@@ -84,6 +84,11 @@ function filterTestModules(modules, modulePath, filePath) {
       return result.concat(stringFilter(modules, modulePath).filter( module => result.indexOf(module) === -1 ));
     }
   }, []);
+
+  if (filteredTestModules.length === 0) {
+    throw new Error(`No tests matched with the filter: ${modulePath || filePath}.`);
+  }
+  return filteredTestModules;
 }
 
 export {

--- a/tests/unit/mocha/filter-test-modules-test.js
+++ b/tests/unit/mocha/filter-test-modules-test.js
@@ -45,7 +45,9 @@ describe('Unit | filter-test-modules', () => {
     });
 
     it('should return an empty list when there is no match', () => {
-      expect(filterTestModules(this.modules, 'no-match')).to.deep.equal([]);
+      expect(() => {
+        filterTestModules(this.modules, 'no-match');
+      }).to.throw(/No tests matched with the filter:/);
     });
 
     it('should return a list of tests matched with a regular expression', () => {
@@ -119,8 +121,9 @@ describe('Unit | filter-test-modules', () => {
     });
 
     it('should return a list of tests matched with a regular expression', () => {
-      expect(filterTestModules(this.modules, null, 'no-match')).to.deep.equal([
-      ]);
+      expect(() => {
+        filterTestModules(this.modules, null, 'no-match');
+      }).to.throw(/No tests matched with the filter:/);
     });
 
     it('should return a list of tests matches with a list of string options', () => {

--- a/tests/unit/qunit/filter-test-modules-test.js
+++ b/tests/unit/qunit/filter-test-modules-test.js
@@ -47,8 +47,9 @@ module('Unit | filter-test-modules', function(hooks) {
     });
 
     test('should return an empty list when there is no match', function(assert) {
-      assert.deepEqual(
-        [], filterTestModules(this.modules, 'no-match')
+      assert.throws(
+        () => filterTestModules(this.modules, 'no-match'),
+        /No tests matched with the filter:/
       );
     });
 
@@ -145,8 +146,9 @@ module('Unit | filter-test-modules', function(hooks) {
     });
 
     test('should return an empty list when there is no match', function(assert) {
-      assert.deepEqual(
-        [], filterTestModules(this.modules, null, 'no-match')
+      assert.throws(
+        () => filterTestModules(this.modules, null, 'no-match'),
+        /No tests matched with the filter:/
       );
     });
 


### PR DESCRIPTION
`filter` and `module` provided by ember-cli throws an error when there are no tests matched with the filter input saying `No tests matched the filter`.  This pr is to throw an error when there are no matching tests with a given input by `file-path` and `module-path` as the same behavior as `filter` and `module`. 

