### PR TITLE
Remove disable-gpu flag

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -14,7 +14,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
Chrome v76 has an issue when starting headless with the `--disable-gpu` flag: https://bugs.chromium.org/p/chromium/issues/detail?id=737678

Turns out this flag was needed to run headless Chrome on Windows, but that limitation has since been addressed and can be removed our testem configs.