### PR TITLE
ensure browserExitHandler is called for global errors

### DIFF
--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -282,7 +282,19 @@ module.exports = TestCommand.extend({
       );
     };
     const browserFailureHandler = function() {
-      if (commands.get('writeExecutionFile')) {
+      // browserFailureHandler is called for disconnect, processError or processExit events.
+      // disconnect and processExit events is fired during global error and successful test runs.
+      // On successful test runs, browserExitHandler should already be called. And is unnecessary
+      // to call it again, so we should return. This is covered by this.finish = true
+      // On global failure cases, it's possible that this.finish is also true. So we must check
+      // the timers set by onProcessExit
+      // https://github.com/testem/testem/blob/master/lib/runners/browser_test_runner.js#L266
+      // or onProcessError in testem.
+      // https://github.com/testem/testem/blob/master/lib/runners/browser_test_runner.js#L252
+      // If either timers is set, we should record the failed browser and call browserExitHandler
+      if (this.finished && (!this.onProcessExitTimer && !this.pendingTimer)) {
+        return;
+      } else if (commands.get('writeExecutionFile')) {
         const browserId = getBrowserId(this.launcher.settings.test_page);
         testemEvents.recordFailedBrowserId(browserId);
       }


### PR DESCRIPTION
**Bug Fix: Test-execution file incorrectly counted all browsers into the `failedBrowser` array**

**Background:**
From the change that landed in #357, `browserFailureHandler`, we removed the `this.finish` check. It is necessary to ensure that global errors that triggers `disconnect`, `processExit` or `processError` events will both be recorded in the test execution file, as well as incrementing the completed browser.
But this introduced a bug, where any  `disconnect` and `processExit` events from successful test execution are considered as failed browsers.

**Resolution:**
Restored the check for `this.finish` while also checking for any global error. If we get a global error, continue with the failure flow. 
Added assertions to ensure the failed browsers array in the test execution file is empty when test successful finishes with no errors. Conversely, added assertions to ensure failed browsers array is not empty when test run fails.