### PR TITLE
Add to validate if testem is available

### DIFF
--- a/addon-test-support/-private/ember-exam-qunit-test-loader.js
+++ b/addon-test-support/-private/ember-exam-qunit-test-loader.js
@@ -126,7 +126,9 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
     this._qunit.moduleDone((metadata) => {
       // testem:module-done-metadata is sent to server to keep track of test module details.
       // 'metadata' contains module name, total number of assertion ran in the module, and module runtime.
-      this._testem.emit('testem:module-done-metadata', metadata);
+      if (typeof this._testem !== 'undefined' && this._testem !== null) {
+        this._testem.emit('testem:module-done-metadata', metadata);
+      }
     });
   }
 

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -17,7 +17,7 @@ function getNumberOfTests(str) {
   return match && parseInt(match[1], 10);
 }
 
-const TOTAL_NUM_TESTS = 64; // Total Number of tests without the global 'Ember.onerror validation tests'
+const TOTAL_NUM_TESTS = 65; // Total Number of tests without the global 'Ember.onerror validation tests'
 
 function getTotalNumberOfTests(output) {
   // In ember-qunit 3.4.0, this new check was added: https://github.com/emberjs/ember-qunit/commit/a7e93c4b4b535dae62fed992b46c00b62bfc83f4
@@ -545,7 +545,7 @@ describe('Acceptance | Exam Command', function() {
         assertOutput(output, 'Browser Id', [1]);
         assert.equal(
           getNumberOfTests(output),
-          26,
+          27,
           'ran all of the tests for browser one'
         );
       });

--- a/tests/unit/qunit/test-loader-test.js
+++ b/tests/unit/qunit/test-loader-test.js
@@ -60,6 +60,27 @@ test('loads all test modules by default', function(assert) {
   ]);
 });
 
+test('loads all test modules when testem object is not available', function(assert) {
+  const undefinedTestem = undefined;
+  const testLoader = new EmberExamTestLoader(
+    undefinedTestem,
+    new Map(),
+    this.qunit
+  );
+  testLoader.loadModules();
+
+  assert.deepEqual(this.requiredModules, [
+    'test-1-test.jshint',
+    'test-2-test.jshint',
+    'test-3-test.jshint',
+    'test-4-test.jshint',
+    'test-1-test',
+    'test-2-test',
+    'test-3-test',
+    'test-4-test'
+  ]);
+});
+
 test('loads modules from a specified partition', function(assert) {
   const testLoader = new EmberExamTestLoader(
     this.testem,


### PR DESCRIPTION
with `ember serve` window.testem is not available when loading test-loader.
https://github.com/ember-cli/ember-exam/blob/master/addon-test-support/load.js#L20

This pr is to validate if testem is available to emit an event for module-metadata