### PR TITLE
Change 'browserFailureHandler' function name to 'browserTerminationHandler' and Add validate to see if a process is available to register process events.

### DIFF
--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -357,7 +357,12 @@ module.exports = TestCommand.extend({
 
     events['tests-start'] = function() {
       if (!init) {
-        // when test runs without launcher (with --no-launch) process object is not avaialble.
+        // process object is instantiated only when browsers are launched by testem server.
+        // 1. `ember test/exam` where browsers are instantiated by testem - process is available
+        // 2. `ember test/exam --server` where browsers can be instantiated by testem or manually
+        // - process is available only when browsers are instantiated by testem
+        // 3. `ember test/exam --serve --no-launch` where browsers are instantiated manually - process is undefined
+        // 4. `ember serve` where browsers are instantiated manually by developer - process is available.
         if (typeof this.process === 'undefined' || this.process === null) {
           this.process.on('processExit', browserTerminationHandler.bind(this));
           this.process.on('processError', browserTerminationHandler.bind(this));

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -319,8 +319,8 @@ module.exports = TestCommand.extend({
       );
     };
 
-    const browserFailureHandler = function() {
-      // browserFailureHandler is called for disconnect, processError or processExit events.
+    const browserTerminationHandler = function() {
+      // browserTerminationHandler is called for disconnect, processError or processExit events.
       // disconnect and processExit events is fired during global error and successful test runs.
       // On successful test runs, browserExitHandler should already be called. And is unnecessary
       // to call it again, so we should return. This is covered by this.finish = true
@@ -332,7 +332,9 @@ module.exports = TestCommand.extend({
       // If either timers is set, we should record the failed browser and call browserExitHandler
       if (this.finished && (!this.onProcessExitTimer && !this.pendingTimer)) {
         return;
-      } else if (commands.get('writeExecutionFile')) {
+      }
+      if (commands.get('writeExecutionFile')) {
+        // when a browser fails with an error record failed browser id.
         const browserId = getBrowserId(this.launcher.settings.test_page);
         testemEvents.recordFailedBrowserId(browserId);
       }
@@ -340,23 +342,26 @@ module.exports = TestCommand.extend({
       browserExitHandler.call(this, true);
     };
 
-    return this._getModuleMetadataAndBrowserExitSocketEvents(browserExitHandler, browserFailureHandler);
+    return this._getModuleMetadataAndBrowserExitSocketEvents(browserExitHandler, browserTerminationHandler);
   },
 
   /**
    * Add browser socket events are needed for both with load-balance and without load-balance
    *
    * @param {Object} browserExitHandler
-   * @param {Object} browserFailureHandler
+   * @param {Object} browserTerminationHandler
    */
-  _getModuleMetadataAndBrowserExitSocketEvents(browserExitHandler, browserFailureHandler) {
+  _getModuleMetadataAndBrowserExitSocketEvents(browserExitHandler, browserTerminationHandler) {
     const events = {};
     let init = false;
 
     events['tests-start'] = function() {
       if (!init) {
-        this.process.on('processExit', browserFailureHandler.bind(this));
-        this.process.on('processError', browserFailureHandler.bind(this));
+        // when test runs without launcher (with --no-launch) process object is not avaialble.
+        if (typeof this.process === 'undefined' || this.process === null) {
+          this.process.on('processExit', browserTerminationHandler.bind(this));
+          this.process.on('processError', browserTerminationHandler.bind(this));
+        }
         init = true;
       }
     };
@@ -364,11 +369,8 @@ module.exports = TestCommand.extend({
     events['after-tests-complete'] = browserExitHandler;
 
     events['disconnect'] = function() {
-      // when test runs without launcher (with --no-launch) process object is not avaialble.
       // To prevent handling exiting browser browser disconnects from errors `disconnect` callback's needed to be registered.
-      if (typeof this.process === 'undefined' || this.process === null) {
-        browserFailureHandler.bind(this)();
-      }
+      browserTerminationHandler.bind(this)();
     }
 
     events['testem:module-done-metadata'] = (details) => {

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -453,7 +453,7 @@ describe('Acceptance | Exam Command', function() {
           'failure-dist',
           '--load-balance',
           '--parallel',
-          '1',
+          '3',
           '--write-execution-file'
         ]).then(assertExpectRejection, error => {
           const output = error.message;


### PR DESCRIPTION
This pr's changes include
1. Name of 'browserFailureHandler' function to 'browserTerminationHandler'
Currently `browesrFailureHandler` is invoked by a multiple events - `processExit`, `processError`, and `disconnect`. The events are emitted when browsers are terminated. However, browser termination doesn't indicate that a browser's exiting due to an error. The name of the function gives a confusion by providing an assumption of the events are invoked by browser errors. 

2. Add validate to see if a process is available to register process events.
`this.process` is only available when browsers are launched via testem. When users manually launch browsers `this.process` is not valid. Due to the reason, checking the process is available before registering process events is required. 

3. Remove `typeof this.process === 'undefined' || this.process === null` in disconnect.
The statement is no longer required to be checked because previously `browserExitHandler` checks browser's completion by recording browser id. Currently implementation checks launcher id rather than browser id which is available for both using `no-launch` and without `no-launch` flag. 
