### PR TITLE
Set up to run deploy after successful builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,11 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
 
+after_success:
+  - if [[ ($TRAVIS_BRANCH == master || -n $TRAVIS_TAG) && $EMBER_TRY_SCENARIO == ember-default ]]; then
+    node_modules/.bin/ember deploy production;
+    fi
+
 install:
   - yarn install --no-lockfile --non-interactive
 


### PR DESCRIPTION
ember-cli-addon-docs enables to create docs: https://ember-cli.com/ember-exam/
it's required to run `ember deploy` to have the docs up to date. The pr is to set up auto deploy for ember-cli-addon-docs to run `ember deploy production` when there is successful build from master.
