### PR TITLE
Check process object is available before register callbacks

### DIFF
--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -363,7 +363,7 @@ module.exports = TestCommand.extend({
         // - process is available only when browsers are instantiated by testem
         // 3. `ember test/exam --serve --no-launch` where browsers are instantiated manually - process is undefined
         // 4. `ember serve` where browsers are instantiated manually by developer - process is available.
-        if (typeof this.process === 'undefined' || this.process === null) {
+        if (typeof this.process !== 'undefined' && this.process !== null) {
           this.process.on('processExit', browserTerminationHandler.bind(this));
           this.process.on('processError', browserTerminationHandler.bind(this));
         }


### PR DESCRIPTION
This pr is to ensure `process` is available before registering callbacks.
