### PR TITLE
updating header comments to fix warnings during "ember build"

### DIFF
--- a/addon-test-support/-private/async-iterator.js
+++ b/addon-test-support/-private/async-iterator.js
@@ -25,12 +25,19 @@ export default class AsyncIterator {
   }
 
   /**
-   * Return whether the response queue is done.
+   * Indicates whether the response queue is done or not.
+   *
+   * @method done
+   * @return {bool} whether the response queue is done or not
    */
   get done() {
     return this._done;
   }
 
+  /**
+   * @method toString
+   * @return {String} the stringified value of the iterator.
+   */
   toString() {
     return `<AsyncIterator (request: ${this._request} response: ${
       this._response
@@ -40,6 +47,7 @@ export default class AsyncIterator {
   /**
    * Handle a response when it's waiting for a response
    *
+   * @method handleResponse
    * @param {*} response
    */
   handleResponse(response) {
@@ -70,6 +78,7 @@ export default class AsyncIterator {
   /**
    * Dispose when an iteration is finished.
    *
+   * @method dispose
    */
   dispose() {
     this._done = true;
@@ -82,6 +91,7 @@ export default class AsyncIterator {
   /**
    * Emit the current request.
    *
+   * @method _makeNextRequest
    */
   _makeNextRequest() {
     this._waiting = true;
@@ -91,6 +101,7 @@ export default class AsyncIterator {
   /**
    * Set a timeout to reject a promise if it doesn't get response within the timeout threshold.
    *
+   * @method _setTimeout
    * @param {*} resolve
    */
   _setTimeout(resolve, reject) {
@@ -121,6 +132,7 @@ export default class AsyncIterator {
    * Gets the next response from the request and resolve the promise.
    * if it's end of the iteration resolve the promise with done being true.
    *
+   * @method next
    * @return {Promise}
    */
   next() {

--- a/addon-test-support/-private/ember-exam-mocha-test-loader.js
+++ b/addon-test-support/-private/ember-exam-mocha-test-loader.js
@@ -24,6 +24,8 @@ export default class EmberExamMochaTestLoader extends TestLoader {
   /**
    * Ember-cli-test-loader instantiates a new TestLoader instance and calls loadModules.
    * EmberExamMochaTestLoader does not support load() in favor of loadModules().
+   *
+   * @method load
    */
   static load() {
     throw new Error('`EmberExamMochaTestLoader` doesn\'t support `load()`.');
@@ -33,6 +35,7 @@ export default class EmberExamMochaTestLoader extends TestLoader {
    * require() collects the full list of modules before requiring each module with
    * super.require, instead of requiring and unseeing a module when each gets loaded.
    *
+   * @method require
    * @param {string} moduleName
    */
   require(moduleName) {
@@ -41,11 +44,15 @@ export default class EmberExamMochaTestLoader extends TestLoader {
 
   /**
    * Make unsee a no-op to avoid any unwanted resets
+   *
+   * @method unsee
    */
   unsee() {}
 
   /**
    * Loads the test modules depending on the urlParam
+   *
+   * @method loadModules
    */
   loadModules() {
     const modulePath = this._urlParams.get('modulePath');

--- a/addon-test-support/-private/ember-exam-qunit-test-loader.js
+++ b/addon-test-support/-private/ember-exam-qunit-test-loader.js
@@ -29,6 +29,8 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
   /**
    * ember-cli-test-loader instantiates a new TestLoader instance and calls loadModules.
    * EmberExamQUnitTestLoader does not support load() in favor of loadModules().
+   *
+   * @method load
    */
   static load() {
     throw new Error('`EmberExamQUnitTestLoader` doesn\'t support `load()`.');
@@ -38,6 +40,7 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
    * require() collects the full list of modules before requiring each module with
    * super.require(), instead of requiring and unseeing a module when each gets loaded.
    *
+   * @method require
    * @param {string} moduleName
    */
   require(moduleName) {
@@ -46,11 +49,15 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
 
   /**
    * Make unsee a no-op to avoid any unwanted resets
+   *
+   * @method unsee
    */
   unsee() {}
 
   /**
    * Loads the test modules depending on the urlParam
+   *
+   * @method loadModules
    */
   loadModules() {
     const loadBalance = this._urlParams.get('loadBalance');
@@ -107,6 +114,7 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
   /**
    * Allow loading one module at a time.
    *
+   * @method loadIndividualModule
    * @param {string} moduleName
    */
   loadIndividualModule(moduleName) {
@@ -121,6 +129,8 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
 
   /**
    * setupModuleMetadataHandler() register QUnit callback to enable generating module metadata file.
+   *
+   * @method setupModuleMetadataHandler
    */
   setupModuleMetadataHandler() {
     this._qunit.testDone((metadata) => {
@@ -135,6 +145,8 @@ export default class EmberExamQUnitTestLoader extends TestLoader {
 
   /**
    * setupLoadBalanceHandlers() registers QUnit callbacks needed for the load-balance option.
+   *
+   * @method setupLoadBalanceHandlers
    */
   setupLoadBalanceHandlers() {
     // nextModuleAsyncIterator handles the async testem events

--- a/addon-test-support/-private/filter-test-modules.js
+++ b/addon-test-support/-private/filter-test-modules.js
@@ -6,6 +6,7 @@ const TEST_PATH_REGEX = /\/tests\/(.*?)$/;
  * Return the matched test.
  * e.g. if an input is '!/weight/' it returns an array, ['!/weight/', '!', 'weight', ''];
  *
+ * @function getRegexFilter
  * @param {*} modulePath
  */
 function getRegexFilter(modulePath) {
@@ -16,6 +17,7 @@ function getRegexFilter(modulePath) {
  * Determine if a given module path is matched with module filter with wildcard.
  * e.g. A given moduleFilter, /tests/integration/*, matches with /tests/integration/foo and /tests/integration/bar
  *
+ * @function wildcardFilter
  * @param {*} module
  * @param {*} moduleFilter
  */
@@ -28,6 +30,7 @@ function wildcardFilter(module, moduleFilter) {
 /**
  * Return a list of test modules that contain a given module path string.
  *
+ * @function stringFilter
  * @param {Array<string>} modules
  * @param {string} moduleFilter
  */
@@ -38,6 +41,7 @@ function stringFilter(modules, moduleFilter) {
 /**
  * Return a list of test modules that matches with a given regular expression.
  *
+ * @function regexFilter
  * @param {Array<string>} modules
  * @param {Array<string>} modulePathRegexFilter
  */
@@ -51,6 +55,7 @@ function regexFilter(modules, modulePathRegexFilter) {
 /**
  * Return a module path that's mapped by a given test file path.
  *
+ * @function convertFilePathToModulePath
  * @param {*} filePath
  */
 function convertFilePathToModulePath(filePath) {
@@ -66,6 +71,7 @@ function convertFilePathToModulePath(filePath) {
 /**
  * Returns a list of test modules that match with the given module path filter or test file path.
  *
+ * @function filterTestModules
  * @param {Array<string>} modules
  * @param {string} modulePath
  * @param {string} filePath

--- a/addon-test-support/-private/get-test-loader.js
+++ b/addon-test-support/-private/get-test-loader.js
@@ -4,7 +4,8 @@
  * Returns ember-exam-qunit-test-loader or ember-exam-mocha-test-loader
  *
  * @export
- * @returns {Object}
+ * @function getTestLoader
+ * @return {Object}
  */
 export default function getTestLoader() {
   if (requirejs.entries['ember-qunit/test-loader']) {

--- a/addon-test-support/-private/get-url-params.js
+++ b/addon-test-support/-private/get-url-params.js
@@ -6,7 +6,8 @@ function decodeQueryParam(param) {
  * Parses the url and return an object containing a param's key and value
  *
  * @export
- * @returns {Object} urlParams
+ * @function getUrlParams
+ * @return {Object} urlParams
  */
 export default function getUrlParams() {
   const urlParams = new Map();

--- a/addon-test-support/-private/patch-testem-output.js
+++ b/addon-test-support/-private/patch-testem-output.js
@@ -3,9 +3,10 @@
 /**
  * Returns a modified test name including browser or partition information
  *
+ * @function updateTestName
  * @param {Map} urlParams
  * @param {string} testName
- * @returns {string} testName
+ * @return {string} testName
  */
 export function updateTestName(urlParams, testName) {
   const split = urlParams.get('split');
@@ -28,6 +29,7 @@ export function updateTestName(urlParams, testName) {
 /**
  * Setup testem test-result event to update the test name when a test completes
  *
+ * @function patchTestemOutput
  * @param {Map} urlParams
  */
 export function patchTestemOutput(urlParams) {

--- a/addon-test-support/-private/split-test-modules.js
+++ b/addon-test-support/-private/split-test-modules.js
@@ -28,14 +28,15 @@ function isNotLintTest(name) {
 }
 
 /**
- * splits the list of modules into unique subset of modules
+ * Splits the list of modules into unique subset of modules
  * return the subset indexed by the partition
  *
  * @export
+ * @function splitTestModules
  * @param {Array<string>} modules
  * @param {number} split
  * @param {number} partitions
- * @returns {Array<string>} tests
+ * @return {Array<string>} tests
  */
 export default function splitTestModules(modules, split, partitions) {
   if (split < 1) {

--- a/addon-test-support/-private/weight-test-modules.js
+++ b/addon-test-support/-private/weight-test-modules.js
@@ -14,6 +14,7 @@ const DEFAULT_WEIGHT = 50;
  * The weight assigned to a module corresponds to its test type execution speed, with slowest being the highest in weight.
  * If the test type is not identifiable from the modulePath, weight default to 50 (ordered after acceptance, but before integration)
  *
+ * @function getWeight
  * @param {string} modulePath File path to a module
  */
 function getWeight(modulePath) {
@@ -29,8 +30,9 @@ function getWeight(modulePath) {
  * Returns the list of modules sorted by its weight
  *
  * @export
+ * @function weightTestModules
  * @param {Array<string>} modules
- * @returns {Array<string>}
+ * @return {Array<string>}
  */
 export default function weightTestModules(modules) {
   const groups = new Map();

--- a/addon-test-support/load.js
+++ b/addon-test-support/load.js
@@ -6,7 +6,8 @@ let loaded = false;
 /**
  * Setup EmberExamTestLoader to enable ember exam functionalities
  *
- * @returns {*} testLoader
+ * @function loadEmberExam
+ * @return {*} testLoader
  */
 export default function loadEmberExam() {
   if (loaded) {

--- a/addon-test-support/start.js
+++ b/addon-test-support/start.js
@@ -5,6 +5,7 @@ import loadEmberExam from 'ember-exam/test-support/load';
 /**
  * Equivalent to ember-qunit or ember-mocha's loadTest() except this does not create a new TestLoader instance
  *
+ * @function loadTests
  * @param {*} testLoader
  */
 function loadTests(testLoader) {
@@ -21,6 +22,7 @@ function loadTests(testLoader) {
  * Ember-exam's own start function to set up EmberExamTestLoader, load tests and calls start() from
  * ember-qunit or ember-mocha
  *
+ * @function start
  * @param {*} qunitOptions
  */
 export default function start(qunitOptions) {


### PR DESCRIPTION
Doing an 'ember build' for ember-exam generates a large number of yuidoc warning messages, usually for a missing type. This PR is to add the relevant yuidoc entries to fix those warnings during build.