### PR TITLE
Update to check ember-mocha version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
   fail_fast: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary TEST_FRAMEWORK=ember-qunit
-    - env: EMBER_TRY_SCENARIO=ember-canary TEST_FRAMEWORK=ember-cli-mocha
+    - env: EMBER_TRY_SCENARIO=ember-canary TEST_FRAMEWORK=ember-mocha
 
   include:
     # runs linting and tests with current locked deps
@@ -35,17 +35,17 @@ jobs:
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
       env: EMBER_TRY_SCENARIO=ember-lts-2.16 TEST_FRAMEWORK=ember-qunit
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.16 TEST_FRAMEWORK=ember-cli-mocha
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.16 TEST_FRAMEWORK=ember-mocha
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18 TEST_FRAMEWORK=ember-qunit
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18 TEST_FRAMEWORK=ember-cli-mocha
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.18 TEST_FRAMEWORK=ember-mocha
     - env: EMBER_TRY_SCENARIO=ember-release TEST_FRAMEWORK=ember-qunit
-    - env: EMBER_TRY_SCENARIO=ember-release TEST_FRAMEWORK=ember-cli-mocha
+    - env: EMBER_TRY_SCENARIO=ember-release TEST_FRAMEWORK=ember-mocha
     - env: EMBER_TRY_SCENARIO=ember-beta TEST_FRAMEWORK=ember-qunit
-    - env: EMBER_TRY_SCENARIO=ember-beta TEST_FRAMEWORK=ember-cli-mocha
+    - env: EMBER_TRY_SCENARIO=ember-beta TEST_FRAMEWORK=ember-mocha
     - env: EMBER_TRY_SCENARIO=ember-canary TEST_FRAMEWORK=ember-qunit
-    - env: EMBER_TRY_SCENARIO=ember-canary TEST_FRAMEWORK=ember-cli-mocha
+    - env: EMBER_TRY_SCENARIO=ember-canary TEST_FRAMEWORK=ember-mocha
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery TEST_FRAMEWORK=ember-qunit
-    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery TEST_FRAMEWORK=ember-cli-mocha
+    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery TEST_FRAMEWORK=ember-mocha
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Code Climate](https://codeclimate.com/github/trentmwillis/ember-exam/badges/gpa.svg)](https://codeclimate.com/github/trentmwillis/ember-exam)
 [![Node Test Coverage](https://codeclimate.com/github/trentmwillis/ember-exam/badges/coverage.svg)](https://codeclimate.com/github/trentmwillis/ember-exam/coverage)
 
-Ember Exam is an addon to allow you more control over how you run your tests when used in conjunction with [Ember QUnit](https://github.com/emberjs/ember-qunit) or [Ember CLI Mocha](https://github.com/ember-cli/ember-cli-mocha). It provides the ability to randomize, split, parallelize, and load-balance your test suite by adding a more robust CLI command.
+Ember Exam is an addon to allow you more control over how you run your tests when used in conjunction with [Ember QUnit](https://github.com/emberjs/ember-qunit) or [Ember Mocha](https://github.com/emberjs/ember-mocha). It provides the ability to randomize, split, parallelize, and load-balance your test suite by adding a more robust CLI command.
 
 It started as a way to help reduce flaky tests and encourage healthy test driven development. It's like [Head & Shoulders](http://www.headandshoulders.com/) for your tests!
 

--- a/bin/install-test-framework.sh
+++ b/bin/install-test-framework.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
-if [ "${TEST_FRAMEWORK}" = "ember-cli-mocha" ]; then
+if [ "${TEST_FRAMEWORK}" = "ember-mocha" ]; then
   yarn remove ember-qunit
-  echo "n" | ember install ember-cli-mocha@0.14.4 @ember/jquery && ember feature:enable jquery-integration
+  echo "n" | ember install ember-mocha@0.16.0 @ember/jquery && ember feature:enable jquery-integration
 fi

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -133,7 +133,7 @@ module.exports = TestCommand.extend({
     const dependencies = pkg.dependencies || {};
     const devDependencies = pkg.devDependencies || {};
 
-    if (dependencies['ember-cli-mocha'] || devDependencies['ember-cli-mocha']) {
+    if (dependencies['ember-mocha'] || devDependencies['ember-mocha']) {
       return 'mocha';
     } else {
       return 'qunit';

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -158,21 +158,21 @@ describe('ExamCommand', function() {
       command = createCommand();
     });
 
-    it('returns mocha if ember-cli-mocha is a dependency', function() {
+    it('returns mocha if ember-mocha is a dependency', function() {
       command.project.pkg.dependencies = {
-        'ember-cli-mocha': '*'
+        'ember-mocha': '*'
       };
       assertFramework(command, 'mocha');
     });
 
-    it('returns mocha if ember-cli-mocha is a dev-dependency', function() {
+    it('returns mocha if ember-mocha is a dev-dependency', function() {
       command.project.pkg.devDependencies = {
-        'ember-cli-mocha': '*'
+        'ember-mocha': '*'
       };
       assertFramework(command, 'mocha');
     });
 
-    it('returns qunit if ember-cli-mocha is not a dependency of any kind', function() {
+    it('returns qunit if ember-mocha is not a dependency of any kind', function() {
       command = createCommand();
       assertFramework(command, 'qunit');
     });


### PR DESCRIPTION
_getTestFramework checks for ember-mocha package instead of ember-cli-mocha (deprecated)
https://github.com/ember-cli/ember-cli-mocha

#471 