### PR TITLE
Dropping support for node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "8"
+  - "10"
 
 addons:
   chrome: stable

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "testdouble": "^3.12.2"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
As node 8 is no longer in maintenance moving node engine in ember-exam from 8 to 10.
https://nodejs.org/en/about/releases/