### PR TITLE
Handle an error thrown in getBrowserId() and Enhance completeBrowserHandler()

### DIFF
--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -288,16 +288,18 @@ module.exports = TestCommand.extend({
       const launcherId = this.launcher.id;
       if (!failed && commands.get('loadBalance')) {
         try {
-          const browserId = getBrowserId(this.launcher.settings.test_page);
+          const browserId = getBrowserId(this.launcher);
           log.info(`Browser ${browserId} exiting. [ # of modules in current module queue ${testemEvents.stateManager.getTestModuleQueue().length} ]`);
         } catch (err) {
-          const message = testemEvents.stateManager.getTestModuleQueue() === null ?
+          const moduleQueueMessage = testemEvents.stateManager.getTestModuleQueue() === null ?
           'testModuleQueue is not set.' :
           `[ # of modules in current module queue ${testemEvents.stateManager.getTestModuleQueue().length} ]`;
+
           if (typeof err === 'object' && err !== null) {
-            err.message = `${err.message} \n ${message}`;
+            err.message = `${err.message} \n ${moduleQueueMessage}`;
+            ui.writeLine(err.message);
           } else {
-            throw new Error(message);
+            throw new Error(moduleQueueMessage);
           }
         }
       }
@@ -334,9 +336,7 @@ module.exports = TestCommand.extend({
         return;
       }
       if (commands.get('writeExecutionFile')) {
-        // when a browser fails with an error record failed browser id.
-        const browserId = getBrowserId(this.launcher.settings.test_page);
-        testemEvents.recordFailedBrowserId(browserId);
+        testemEvents.recordFailedBrowserId(this.launcher, ui);
       }
 
       browserExitHandler.call(this, true);
@@ -353,6 +353,7 @@ module.exports = TestCommand.extend({
    */
   _getModuleMetadataAndBrowserExitSocketEvents(browserExitHandler, browserTerminationHandler) {
     const events = {};
+    const testemEvents = this.testemEvents;
     let init = false;
 
     events['tests-start'] = function() {
@@ -368,6 +369,10 @@ module.exports = TestCommand.extend({
           this.process.on('processError', browserTerminationHandler.bind(this));
         }
         init = true;
+      }
+
+      if (typeof this.launcher !== 'undefined' && this.launcher !== null) {
+        testemEvents.recordStartedLauncherId(this.launcher.id);
       }
     };
 
@@ -407,6 +412,8 @@ module.exports = TestCommand.extend({
    */
   _getLoadBalancingBrowserSocketEvents({ isLoadBalance, isReplayExecution, isWriteExecutionFile } , testemEvents) {
     const events = {};
+    const ui = this.ui;
+
     events['testem:set-modules-queue'] = function(modules, browserId) {
       testemEvents.setModuleQueue(
         browserId,
@@ -424,8 +431,7 @@ module.exports = TestCommand.extend({
     };
     events['test-result'] = function(result) {
       if (result.failed && isWriteExecutionFile) {
-        const browserId = getBrowserId(this.launcher.settings.test_page);
-        testemEvents.recordFailedBrowserId(browserId);
+          testemEvents.recordFailedBrowserId(this.launcher, ui);
       }
     };
 

--- a/lib/utils/execution-state-manager.js
+++ b/lib/utils/execution-state-manager.js
@@ -7,6 +7,9 @@
  */
 class ExecutionStateManager {
   constructor(replayExecutionMap) {
+    // A set of launcher id of attached browsers
+    this._startedLaunchers = new Set();
+
     // A map of browserId to test modules executed on that browser read from test-execution.json.
     this._replayExecutionMap = replayExecutionMap || null;
 
@@ -25,6 +28,25 @@ class ExecutionStateManager {
 
     // A map of browserId to an array of test modules. This is used by `--replay-execution`
     this._replayExecutionModuleQueue = null;
+  }
+
+  /**
+   * Returns the startedLaunchers
+   *
+   * @returns {Set}
+   */
+  getStartedLaunchers() {
+    return this._startedLaunchers;
+  }
+
+  /**
+   * Add a new laucnher id to the startedLaunchers array.
+   *
+   * @param {number} launcherId
+   * @returns {Boolean}
+   */
+  addToStartedLaunchers(launcherId) {
+    return this._startedLaunchers.add(launcherId);
   }
 
   /**

--- a/lib/utils/test-page-helper.js
+++ b/lib/utils/test-page-helper.js
@@ -123,18 +123,22 @@ function combineOptionValueIntoArray(optionValue) {
 }
 
 /**
- * Returns the browserId within the testPage string
+ * Returns the browserId of launcher
  *
- * @param {string} testPage
+ * @param {Object} launcher
  * @return {string}
  */
-function getBrowserId(testPage) {
-  const browserId = /browser=\s*([0-9]*)/.exec(testPage);
+function getBrowserId(launcher) {
+  try {
+    const testPage = launcher.settings.test_page;
+    const browserIdMatch =/browser=\s*([0-9]*)/.exec(testPage);
 
-  if (Array.isArray(browserId) !== null && browserId !== null) {
-    return browserId[1];
-  } else {
-    throw new Error('Browser Id can\'t be found.');
+    if (Array.isArray(browserIdMatch) !== null && browserIdMatch !== null) {
+      return browserIdMatch[1];
+    }
+  } catch(err) {
+    const errMsg = `${err.message} \n${err.stack} \nLauncher Settings: ${JSON.stringify(launcher.settings, null, 2)}`;
+    throw new Error(errMsg);
   }
 }
 

--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -3,6 +3,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const ExecutionStateManager = require('./execution-state-manager');
+const { getBrowserId } = require('../utils/test-page-helper');
 const writeJsonToFile = require('./file-system-helper');
 
 /**
@@ -132,6 +133,15 @@ class TestemEvents {
   }
 
   /**
+   * Record the launched browser id
+   *
+   * @param {number} browserId
+   */
+  recordStartedLauncherId(browserId) {
+    this.stateManager.addToStartedLaunchers(browserId);
+  }
+
+  /**
    * Record the module run details to the stateManager
    *
    * @param {Object} metaData
@@ -140,13 +150,20 @@ class TestemEvents {
     this.stateManager.addToModuleMetadata(metaData);
   }
 
-  /**
-   * Record the failed browserId to the stateManager
-   *
-   * @param {number} browserId
-   */
-  recordFailedBrowserId(browserId) {
-    if (!this.stateManager.containsFailedBrowser(browserId)) {
+/**
+ * Gets browser id of launcher and stores the browser id stateManager
+ *
+ * @param {Object} launcher
+ * @param {Object} ui
+ */
+  recordFailedBrowserId(launcher, ui) {
+    let browserId;
+    try {
+      browserId = getBrowserId(launcher);
+    } catch(err) {
+      ui.writeLine(err.message);
+    }
+    if ((browserId !== null || typeof browserId !== 'undefined') && !this.stateManager.containsFailedBrowser(browserId)) {
       this.stateManager.addFailedBrowsers(browserId);
     }
   }
@@ -182,15 +199,21 @@ class TestemEvents {
    * @param {Object} currentDate
    */
   completedBrowsersHandler(browserCount, launcherId, ui, commands, currentDate) {
+    const browsersStarted = this.stateManager.getStartedLaunchers();
     let browsersCompleted = false;
 
     this.stateManager.incrementCompletedBrowsers(launcherId);
-    if (this.stateManager.getCompletedBrowser() === browserCount) {
+    if (this.stateManager.getCompletedBrowser() === browsersStarted.size) {
       if (commands.get('writeModuleMetadataFile')) {
         const moduleDetailFileName = path.join(this.root, `module-metadata-${currentDate}.json`);
         const sortedModuleMetadata = getSortedModuleMetaData(this.stateManager.getModuleMetadata());
 
-        writeJsonToFile(moduleDetailFileName, Array.from(sortedModuleMetadata.values()),{ spaces: 2 });
+        writeJsonToFile(moduleDetailFileName,
+          {
+            requested: `${browserCount} browser(s)`,
+            launched: `${browsersStarted.size} browser(s)`,
+            modules: Array.from(sortedModuleMetadata.values())
+          },{ spaces: 2 });
         ui.writeLine(`\nExecution module details were recorded at ${moduleDetailFileName}`);
       }
 
@@ -201,6 +224,8 @@ class TestemEvents {
         writeJsonToFile(testExecutionPath, moduleMapJson, { spaces: 2 });
         ui.writeLine(`\nExecution was recorded at ${testExecutionPath}`);
       }
+
+      ui.writeLine(`Out of requested ${browserCount} browser(s), ${browsersStarted.size} browser(s) has launched.`);
 
       // --server mode allows rerun of tests by refreshing the browser
       // replayExecutionMap should be reused so the test-execution json

--- a/node-tests/unit/utils/test-page-helper-test.js
+++ b/node-tests/unit/utils/test-page-helper-test.js
@@ -39,13 +39,21 @@ describe('TestPageHelper', function() {
 
   describe('getBrowserId', function() {
     it('should return the correct browserId', function() {
-      assert.equal(getBrowserId('loadBalance&browser=1'), 1);
+      const launcher = {
+        settings: {
+          test_page: 'loadBalance&browser=1'
+        }
+      }
+      assert.equal(getBrowserId(launcher), 1);
     });
 
-    it('should return 0 if no browser param is found in the test page', function() {
+    it('should throw an error if the launcher does not have test page set', function() {
+      const launcher = {
+        foo: 'bar'
+      }
       assert.throws(() => {
-        getBrowserId('loadBalance');
-      }, /Browser Id can't be found./);
+        getBrowserId(launcher);
+      }, /Launcher Settings:/);
     });
   });
 


### PR DESCRIPTION
**Background**
`--wmmf` and `--wef` are two options in order to generate test execution data such as test module metadata and test execution details, e.g. with `--wmmf` it creates a json file which contains duration, test stats such as number of passed, failed, and skipped tests of modules executed. Current implementation achieves this feature by saving test module information while executing tests and creating a json file with the information as a browser(s) complete running all tests. 

**Problem Statement**
An issue is raised when executing tests with multiple tests. With multiple browsers, ember-exam currently uses a number of browsers passed by `--parallel` with `--load-balance` or `--split` and compares the number to browsers exited. However, if browsers are never launched by some other reasons then exiting browsers never match with the total number of browser(s) that are initially passed. 

For example, when executing `ember exam --load-balance --parallel 10` for some reasons 2 out of 10 browsers were not able to be launched and only 8 browsers served to run tests. A number of browser(s) to be wanted to launch is 10 but exited browsers is 8. Because the two numbers (8 and 10) are different `--wmmf` and `--wef` will not create any files.

**Solution**
The pr changes to compare a number of exited browsers to "launched" browsers rather than number passed by the option (`--split` or `--parallel`). 


Other than the issue,
the pr also makes change the way it handles an error thrown in `getBrowsersId()`.

