### PR TITLE
Fix invalid ES module usage

### DIFF
--- a/addon-test-support/load.js
+++ b/addon-test-support/load.js
@@ -1,4 +1,4 @@
-import TestemOutput from './-private/patch-testem-output';
+import { patchTestemOutput } from './-private/patch-testem-output';
 import getTestLoader from './-private/get-test-loader';
 
 let loaded = false;
@@ -21,7 +21,7 @@ export default function loadEmberExam() {
   const testLoader = new EmberExamTestLoader(window.Testem);
 
   if (window.Testem) {
-    TestemOutput.patchTestemOutput(testLoader.urlParams);
+    patchTestemOutput(testLoader.urlParams);
   }
 
   return testLoader;


### PR DESCRIPTION
This was not actually valid Javascript. `./-private/patch-testem-output` exports two functions, not a default export. It accidentally works due to an old compatibility feature. It will not work in Embroider or any other build system that follows the ES module spec.