### PR TITLE
Docs: Fix information on Load Balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,8 @@ ok 3 Chrome 66.0 - Exam Partition 1 - browser Id 3 - some the other test
 1. The `--load-balance` option is currently only supported in CI mode and for that reason no-launch cannot be used with load-balance.
 2. You must be using `ember-cli` version 3.2.0 or greater for load balancing and test failure reproduction features to work properly.
 3. You must be using `ember-qunit` version 4.1.1 or greater for this feature to work properly.
-4. You must be using `qunit` version 2.8.0 or greater for this feature to work properly.
+4. You must be using `qunit` version 2.13.0 or greater for this feature to work properly.
 5. This feature is not currently supported by Mocha.
-6. `--random[=<seed>]` does not (currently) work with load balancing. This will be fixed once https://github.com/qunitjs/qunit/pull/1417 lands. 
 
 ##### Test Failure Reproduction
 

--- a/tests/dummy/app/templates/docs/load-balancing.md
+++ b/tests/dummy/app/templates/docs/load-balancing.md
@@ -39,7 +39,7 @@ ok 3 Chrome 66.0 - Exam Partition 1 - browser Id 3 - some the other test
 1. The `--load-balance` option is currently only supported in CI mode and for that reason no-launch cannot be used with load-balance.
 2. You must be using `ember-cli` version 3.2.0 or greater for load balancing and test failure reproduction features to work properly.
 3. You must be using `ember-qunit` version 4.1.1 or greater for this feature to work properly.
-4. You must be using `qunit` version 2.8.0 or greater for this feature to work properly.
+4. You must be using `qunit` version 2.13.0 or greater for this feature to work properly.
 5. This feature is not currently supported by Mocha.
 
 ## Test Failure Reproduction


### PR DESCRIPTION
fixes #643 

> --random[=<seed>] does not (currently) work with load balancing. This will be fixed once qunitjs/qunit/pull/1417 lands.

pr#1417 is in the release [qunit@2.13.0](https://github.com/qunitjs/qunit/releases/tag/2.13.0)