### PR TITLE
fix: automatic import of ember-qunit and qunit in ember-mocha projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,28 +15,35 @@ module.exports = {
     this._super.init.apply(this, arguments);
     let versionChecker = new VersionChecker(this.project);
 
-    const hasMagicallyProvidedQUnit = versionChecker
-      .for('ember-qunit')
-      .lt('5.0.0-beta.1');
-
     let options = {
       exclude: ['ember-mocha', 'mocha'],
     };
 
-    // Ember-qunit < 5 provides an AMD shim for qunit but newer versions now use
-    // ember-auto-import to include qunit. This means that qunit is no
-    // longer available for addons (if the parent app is using ember-qunit > 5) to
-    // directly import under embroider unless they are using ember-auto-import
-    // themselves. This condidionally falls back to not using ember-auto-import
-    // when the parent app is providing qunit because without this we would double
-    // include qunit resulting in a runtime error (qunit detects if it as
-    // already be added to the window object and errors if so).
-    if (hasMagicallyProvidedQUnit) {
-      this.options = this.options || {};
-      options.exclude.push('qunit');
-      this.options.autoImport = options;
+    const hasEmberMocha = versionChecker.for('ember-mocha').exists();
+
+    if (hasEmberMocha) {
+      // Exclude automatic import for ember-qunit and qunit when project use ember-mocha
+      options.exclude.push('ember-qunit', 'qunit');
     } else {
-      this.options.autoImport = options;
+      const hasMagicallyProvidedQUnit = versionChecker
+        .for('ember-qunit')
+        .lt('5.0.0-beta.1');
+
+      // Ember-qunit < 5 provides an AMD shim for qunit but newer versions now use
+      // ember-auto-import to include qunit. This means that qunit is no
+      // longer available for addons (if the parent app is using ember-qunit > 5) to
+      // directly import under embroider unless they are using ember-auto-import
+      // themselves. This condidionally falls back to not using ember-auto-import
+      // when the parent app is providing qunit because without this we would double
+      // include qunit resulting in a runtime error (qunit detects if it as
+      // already be added to the window object and errors if so).
+
+      if (hasMagicallyProvidedQUnit) {
+        options.exclude.push('qunit');
+      }
     }
+
+    this.options = this.options || {};
+    this.options.autoImport = options;
   },
 };


### PR DESCRIPTION
Should fix https://github.com/ember-cli/ember-exam/issues/666

It was trying to auto-import `ember-qunit` and `qunit` in projects using `ember-mocha`, leading to build errors

___

Tested 
- on a public project using `ember-mocha@0.16.2`, see https://github.com/ndekeister-us/Admin/pull/1 
  - commit `c6dec4ba829975297d00f0c3fe438f052b1bd257` -> it will now build the project and run tests (there is maybe another issue with ember-cli-mirage, see https://github.com/miragejs/ember-cli-mirage/pull/2209, but i'm not able to reproduce it anymore so maybe was linked to something wrong in my environment)
- on a private project using `ember-qunit@5.x.x`
- on a private project using `ember-qunit@4.x.x`