### PR TITLE
CI: Disable Ember.js v4 scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
           - ember-lts-3.16
           - ember-lts-3.12
           - ember-release
-          - ember-beta
-          - ember-canary
+          # temporarily disabled until we've fixed support for Ember.js v4
+          # - ember-beta
+          # - ember-canary
           - ember-qunit-4
 
     steps:


### PR DESCRIPTION
> Error: To use these addons, your app needs ember-auto-import >= 2: ember-source

We're currently still on ember-auto-import v1, because upgrading to v2 would be a breaking change. This PR disables the Ember.js v4 scenarios for now, until we've fixed the issue.