### PR TITLE
Ember exam failing when browser ID not found, return 0 

### DIFF
--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -294,9 +294,9 @@ module.exports = TestCommand.extend({
       if (!failed && commands.get('loadBalance')) {
         const browserId = getBrowserId(this.launcher);
         log.info(
-            `Browser ${browserId} exiting. [ # of modules in current module queue ${
-              testemEvents.stateManager.getTestModuleQueue().length
-            } ]`
+          `Browser ${browserId} exiting. [ # of modules in current module queue ${
+            testemEvents.stateManager.getTestModuleQueue().length
+          } ]`
         );
         // if getBrowserId cannot get the browserId
         // but the test queue is not empty, report the number of test modules left in the queue
@@ -306,7 +306,8 @@ module.exports = TestCommand.extend({
             ui.writeLine(
               `[ # of modules in current module queue ${
                 testemEvents.stateManager.getTestModuleQueue().length
-              } ]`);
+              } ]`
+            );
           } else {
             throw new Error('testModuleQueue is not set.');
           }

--- a/lib/utils/test-page-helper.js
+++ b/lib/utils/test-page-helper.js
@@ -133,7 +133,7 @@ function getBrowserId(launcher) {
     if (Array.isArray(browserIdMatch) !== null && browserIdMatch !== null) {
       return browserIdMatch[1];
     }
-  } catch(err) {
+  } catch (err) {
     const errMsg = `${err.message} \n${
       err.stack
     } \nLauncher Settings: ${JSON.stringify(launcher.settings, null, 2)}`;


### PR DESCRIPTION
There has sporadic reports of ember-exam failing for "Browser ID not found" in v4.0.9, even though all the tests from execution has completed. So failing the test execution when all tests pass because of test infrastructure is a bad experience for users.

Context: `getBrowserId` is used for the debug logs & execution file to map the test modules to a browser Id. The logs from the failure has always been from writing to the debug logs. My hunch is the launcher settings is cleared (a race condition) before it's used to for the debug log.

This change will `console.warn` rather than throw new Error when there are problems with getting the `browserId` from `launcher.settings.test_page`. This way, the execution should finish successfully even if it wasn't able to get the browserId.