### PR TITLE
Wait for all browser to completet beforer cleaning up StateManager

### DIFF
--- a/lib/utils/testem-events.js
+++ b/lib/utils/testem-events.js
@@ -224,7 +224,8 @@ class TestemEvents {
     let browsersCompleted = false;
 
     this.stateManager.incrementCompletedBrowsers(launcherId);
-    if (this.stateManager.getCompletedBrowser() === browsersStarted.size) {
+    const completedBrowser = this.stateManager.getCompletedBrowser();
+    if (completedBrowser === browsersStarted.size) {
       if (commands.get('writeModuleMetadataFile')) {
         const moduleDetailFileName = path.join(
           this.root,
@@ -260,9 +261,16 @@ class TestemEvents {
       }
 
       ui.writeLine(
-        `Out of requested ${browserCount} browser(s), ${browsersStarted.size} browser(s) has launched.`
+        `Out of requested ${browserCount} browser(s), ${browsersStarted.size} browser(s) was launched & completed.`
       );
 
+      if (browserCount !== browsersStarted.size) {
+        ui.writeLine('Waiting for remaining browsers to exited.');
+      }
+    }
+
+    if (completedBrowser === browserCount) {
+      ui.writeLine('All browsers to exited.');
       // --server mode allows rerun of tests by refreshing the browser
       // replayExecutionMap should be reused so the test-execution json
       // does not need to be reread

--- a/node-tests/unit/utils/testem-events-test.js
+++ b/node-tests/unit/utils/testem-events-test.js
@@ -436,8 +436,8 @@ describe('TestemEvents', function () {
       this.testemEvents.stateManager.addModuleNameToReplayExecutionMap('b', 2);
 
       this.testemEvents.completedBrowsersHandler(
-        1,
-        1,
+        2,
+        1011,
         mockUi,
         new Map([['loadBalance', true]]),
         '0000'
@@ -456,7 +456,7 @@ describe('TestemEvents', function () {
 
       this.testemEvents.completedBrowsersHandler(
         1,
-        1,
+        1010,
         mockUi,
         new Map([['loadBalance', true]]),
         '0000'
@@ -486,8 +486,8 @@ describe('TestemEvents', function () {
       this.testemEvents.stateManager.addToStartedLaunchers(1010);
 
       this.testemEvents.completedBrowsersHandler(
-        4,
         1,
+        1010,
         mockUi,
         new Map([['loadBalance', true]]),
         '0000'
@@ -505,6 +505,36 @@ describe('TestemEvents', function () {
       assert.deepEqual(
         this.testemEvents.stateManager.getReplayExecutionMap(),
         mockReplayExecutionMap
+      );
+    });
+
+    it('should clean up states from stateManager when all launched browsers exited', function () {
+      this.testemEvents.stateManager.setTestModuleQueue([]);
+      this.testemEvents.stateManager.addToStartedLaunchers(1010);
+      this.testemEvents.stateManager.addToStartedLaunchers(1011);
+
+      this.testemEvents.completedBrowsersHandler(
+        2,
+        1010,
+        mockUi,
+        new Map([['loadBalance', true]]),
+        '0000'
+      );
+
+      assert.deepEqual(this.testemEvents.stateManager.getModuleMap().size, 0);
+      assert.deepEqual(this.testemEvents.stateManager.getTestModuleQueue(), []);
+
+      this.testemEvents.completedBrowsersHandler(
+        2,
+        1011,
+        mockUi,
+        new Map([['loadBalance', true]]),
+        '0000'
+      );
+
+      assert.deepEqual(
+        this.testemEvents.stateManager.getTestModuleQueue(),
+        null
       );
     });
   });


### PR DESCRIPTION
Problem:
For test executions with a small number of tests but was triggered to run with many browsers, it's often the case that not every single browser will receive a test when running with load-balance.
The existing `if (this.stateManager.getCompletedBrowser() === browsersStarted.size) {` will prematurely reset the stateManager when lingering browsers has not exited. This causes the run to fail with 'No ModuleQueue set' error when a browser that took longer to instantiate sends a `getNextModule` event

Resolution:
By adding `if (completedBrowser === browserCount) {`, we will wait for all browsers to exit prior to resetting the stateManager. Preventing us from hitting 'No ModuleQueue set' error.