### PR TITLE
CI: Disable failing `ember-release` scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
           - ember-lts-3.20
           - ember-lts-3.16
           - ember-lts-3.12
-          - ember-release
           # temporarily disabled until we've fixed support for Ember.js v4
+          # - ember-release
           # - ember-beta
           # - ember-canary
           - ember-qunit-4


### PR DESCRIPTION
Ember.js 4.x is causing issues... :-(

This PR at least makes CI green again, while we fix things.