### PR TITLE
Drop support for Ember 3.19 and below

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,6 @@ jobs:
           - embroider-optimized-with-mocha
           - ember-lts-3.24
           - ember-lts-3.20
-          - ember-lts-3.16
-          - ember-lts-3.12
           # temporarily disabled until we've fixed support for Ember.js v4
           # - ember-release
           # - ember-beta

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -34,22 +34,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.12',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.12.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.16',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.16.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.20',
         npm: {
           devDependencies: {


### PR DESCRIPTION
This is unfortunately required to unblock the ember-cli-addon-docs update, which is required to unblock our Ember.js 4.x support here 🙈 