### PR TITLE
Delete unused `herp-derp` component

### DIFF
--- a/tests/dummy/app/components/herp-derp.js
+++ b/tests/dummy/app/components/herp-derp.js
@@ -1,2 +1,0 @@
-import Component from '@ember/component';
-export default Component.extend({});


### PR DESCRIPTION
This component was introduced by ea0522e3eb221aee528301a25454795c8700db3e for testing purposes, but seems to no longer be used anywhere