### PR TITLE
Upgrade `@embroider/*` packages to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "dependencies": {
-    "@embroider/macros": "^0.48.1",
+    "@embroider/macros": "^1.0.0",
     "chalk": "^4.1.1",
     "cli-table3": "^0.6.0",
     "debug": "^4.2.0",
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@ember/optional-features": "2.0.0",
     "@ember/test-helpers": "2.6.0",
-    "@embroider/test-setup": "0.48.1",
+    "@embroider/test-setup": "^1.0.0",
     "auto-dist-tag": "2.1.1",
     "babel-eslint": "10.1.0",
     "codeclimate-test-reporter": "0.5.1",

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,7 +21,7 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="/testem.js" integrity=""></script>
+    <script src="/testem.js" integrity="" data-embroider-ignore></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>

--- a/tests/unit/qunit/async-iterator-test.js
+++ b/tests/unit/qunit/async-iterator-test.js
@@ -6,7 +6,7 @@ import {
 } from '@embroider/macros';
 
 if (macroCondition(dependencySatisfies('ember-qunit', '*'))) {
-  let { module, test } = importSync('qunit');
+  let { module, test } = importSync('qunit').default;
 
   module('Unit | Qunit | async-iterator', {
     beforeEach() {

--- a/tests/unit/qunit/filter-test-modules-test.js
+++ b/tests/unit/qunit/filter-test-modules-test.js
@@ -9,7 +9,7 @@ import {
 } from '@embroider/macros';
 
 if (macroCondition(dependencySatisfies('ember-qunit', '*'))) {
-  let { module, test } = importSync('qunit');
+  let { module, test } = importSync('qunit').default;
   let { setupTest } = importSync('ember-qunit');
 
   module('Unit | Qunit | filter-test-modules', function () {

--- a/tests/unit/qunit/multiple-edge-cases-test.js
+++ b/tests/unit/qunit/multiple-edge-cases-test.js
@@ -5,7 +5,7 @@ import {
 } from '@embroider/macros';
 
 if (macroCondition(dependencySatisfies('ember-qunit', '*'))) {
-  let { module, test } = importSync('qunit');
+  let { module, test } = importSync('qunit').default;
 
   module('Qunit | #3: Module With Multiple Edge Case Tests');
 

--- a/tests/unit/qunit/multiple-ember-tests-test.js
+++ b/tests/unit/qunit/multiple-ember-tests-test.js
@@ -5,7 +5,7 @@ import {
 } from '@embroider/macros';
 
 if (macroCondition(dependencySatisfies('ember-qunit', '*'))) {
-  let { module, test } = importSync('qunit');
+  let { module, test } = importSync('qunit').default;
   let { setupTest } = importSync('ember-qunit');
 
   module('Qunit | #1: Module-For With Multiple Tests', function (hooks) {

--- a/tests/unit/qunit/multiple-tests-test.js
+++ b/tests/unit/qunit/multiple-tests-test.js
@@ -5,7 +5,7 @@ import {
 } from '@embroider/macros';
 
 if (macroCondition(dependencySatisfies('ember-qunit', '*'))) {
-  let { module, test } = importSync('qunit');
+  let { module, test } = importSync('qunit').default;
 
   module('Qunit | #2: Module With Multiple Tests');
 

--- a/tests/unit/qunit/test-loader-test.js
+++ b/tests/unit/qunit/test-loader-test.js
@@ -6,12 +6,7 @@ import {
 } from '@embroider/macros';
 
 if (macroCondition(dependencySatisfies('ember-qunit', '*'))) {
-  let QUnit;
-  if (dependencySatisfies('ember-qunit', '>=5')) {
-    QUnit = importSync('qunit');
-  } else {
-    QUnit = importSync('qunit').default;
-  }
+  let QUnit = importSync('qunit').default;
 
   let { module, test } = QUnit;
 

--- a/tests/unit/qunit/testem-output-test.js
+++ b/tests/unit/qunit/testem-output-test.js
@@ -6,7 +6,7 @@ import {
 } from '@embroider/macros';
 
 if (macroCondition(dependencySatisfies('ember-qunit', '*'))) {
-  let { module, test } = importSync('qunit');
+  let { module, test } = importSync('qunit').default;
 
   module('Unit | Qunit | patch-testem-output', () => {
     test('add partition number to test name when `split` is passed', function (assert) {

--- a/tests/unit/qunit/weight-test-modules-test.js
+++ b/tests/unit/qunit/weight-test-modules-test.js
@@ -6,7 +6,7 @@ import {
 } from '@embroider/macros';
 
 if (macroCondition(dependencySatisfies('ember-qunit', '*'))) {
-  let { module, test } = importSync('qunit');
+  let { module, test } = importSync('qunit').default;
 
   module('Unit | Qunit | weight-test-modules', () => {
     test('should sort a list of file paths by weight', function (assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,19 +1263,6 @@
     resolve "^1.20.0"
     semver "^7.3.2"
 
-"@embroider/macros@^0.48.1":
-  version "0.48.1"
-  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.48.1.tgz#fc1fd10857d40e80a20c0d366a1a8007aa424e83"
-  integrity sha512-JtcOL3pSxI8prstQomzNNHPBqG1K5JwrIuZwH+Q9TK4nONIH2F4z0Z0pd0SZmTEjF17E4gZN3g1J3vSX4zKuww==
-  dependencies:
-    "@embroider/shared-internals" "0.48.1"
-    assert-never "^1.2.1"
-    ember-cli-babel "^7.26.6"
-    find-up "^5.0.0"
-    lodash "^4.17.21"
-    resolve "^1.20.0"
-    semver "^7.3.2"
-
 "@embroider/shared-internals@0.43.5":
   version "0.43.5"
   resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.43.5.tgz#4269208095452c23bfa4f08554fd8f7ed7b83a83"
@@ -1301,19 +1288,6 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/shared-internals@0.48.1":
-  version "0.48.1"
-  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.48.1.tgz#4f0dcde8dba2fa47c862746898a1846a31e27f80"
-  integrity sha512-6Q73QXGUQianIb3xRpMNl8VMECSatA1NhjXxeIyYzwKraWhhMBpXvysLpbJ8ib1rQe1ajmkoDdXgT5pAnVMXrg==
-  dependencies:
-    babel-import-util "^0.2.0"
-    ember-rfc176-data "^0.3.17"
-    fs-extra "^9.1.0"
-    lodash "^4.17.21"
-    resolve-package-path "^4.0.1"
-    semver "^7.3.5"
-    typescript-memoize "^1.0.1"
-
 "@embroider/shared-internals@1.0.0", "@embroider/shared-internals@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-1.0.0.tgz#b081708ac79e4582f17ba0f3e3796e6612a8976c"
@@ -1327,10 +1301,10 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/test-setup@0.48.1":
-  version "0.48.1"
-  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.48.1.tgz#f64da84f8241433d0ba92154fa1eb3137ecd4df8"
-  integrity sha512-MmYTgQMDVDrZPvxeT27LTUD/BOum21ip1tEYv5H/StSeTZyZQ861Q+8HXQUFTVF/HFjGAB1c/BAgnw+8hO1ueA==
+"@embroider/test-setup@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-1.0.0.tgz#f0841345326bcb55eee8437be37f3a8207146b37"
+  integrity sha512-jnrzNyL0mUZ+DTY59s4Yr/V+NgECpwKxuxdKJOr0hNCxC6Kpo5Dagjz22tEyiMOkZhuDdZ4qAqmTUpeu8taLnQ==
   dependencies:
     lodash "^4.17.21"
     resolve "^1.20.0"
@@ -6352,7 +6326,7 @@ ember-cli-addon-docs@4.2.1:
     ember-fetch "^8.1.1"
     ember-get-config "^0.5.0"
     ember-keyboard "^7.0.0-beta.0"
-    ember-modal-dialog "github:yapplabs/ember-modal-dialog#76b74f1c4b791fed5b084836c3b1c8c54836ac71"
+    ember-modal-dialog yapplabs/ember-modal-dialog#76b74f1c4b791fed5b084836c3b1c8c54836ac71
     ember-responsive "^4.0.2"
     ember-router-generator "^2.0.0"
     ember-router-scroll "^4.1.2"
@@ -7019,9 +6993,8 @@ ember-load-initializers@2.1.2:
     ember-cli-babel "^7.13.0"
     ember-cli-typescript "^2.0.2"
 
-"ember-modal-dialog@github:yapplabs/ember-modal-dialog#76b74f1c4b791fed5b084836c3b1c8c54836ac71":
+ember-modal-dialog@yapplabs/ember-modal-dialog#76b74f1c4b791fed5b084836c3b1c8c54836ac71:
   version "4.0.0-alpha.1"
-  uid "76b74f1c4b791fed5b084836c3b1c8c54836ac71"
   resolved "https://codeload.github.com/yapplabs/ember-modal-dialog/tar.gz/76b74f1c4b791fed5b084836c3b1c8c54836ac71"
   dependencies:
     "@embroider/macros" "^0.43.5"


### PR DESCRIPTION
This supersedes #838 and #822 and makes CI pass.
This should help ecosystem migrate to v1 of `@embroider/*` packages.