### PR TITLE
Add preserveTestName CLI flag to remove partition and browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The [documentation website](https://ember-cli.github.io/ember-exam/) contains ex
     + [Split Test Parallelization](#split-test-parallelization)
   * [Test Load Balancing](#test-load-balancing)
       - [Test Failure Reproduction](#test-failure-reproduction)
+  * [Preserve Test Name](#preserve-test-name)
 - [Advanced Configuration](#advanced-configuration)
   * [Ember Try & CI Integration](#ember-try--ci-integration)
   * [Test Suite Segmentation](#test-suite-segmentation)
@@ -374,6 +375,33 @@ $ ember exam --replay-execution=test-execution-000000.json
 2. You must be using `ember-qunit` version 4.1.1 or greater for this feature to work properly.
 3. You must be using `qunit` version 2.8.0 or greater for this feature to work properly.
 4. This feature is not currently supported by Mocha.
+
+#### Preserve Test Name
+
+When using `--split` and/or `--load-balance` the output will look something like:
+
+```bash
+# ember exam --split=2 --partition=1 --parallel=3 --load-balance
+ok 1 Chrome 66.0 - Exam Partition 1 - browser Id 1 - some test
+ok 2 Chrome 66.0 - Exam Partition 1 - browser Id 2 - another test
+ok 3 Chrome 66.0 - Exam Partition 1 - browser Id 3 - some the other test
+```
+However, if you change the amount of parallelization, or randomize accross partitions, the output will change for the same test, which may be an issue if you are tracking test insights over time. 
+
+```bash
+# ember exam --split=2 --partition=1 --parallel=2 --load-balance
+ok 1 Chrome 66.0 - Exam Partition 1 - browser Id 2 - some test
+ok 2 Chrome 66.0 - Exam Partition 1 - browser Id 1 - another test
+ok 3 Chrome 66.0 - Exam Partition 1 - browser Id 2 - some the other test
+```
+You can add `--preserve-test-name` to remove the dynamic segments of the output (partition and browser) to ensure the output test names are always the same.
+
+```bash
+# ember exam --split=2 --partition=1 --parallel=3 --load-balance --preserve-test-name
+ok 1 Chrome 66.0 - some test
+ok 2 Chrome 66.0 - another test
+ok 3 Chrome 66.0 - some the other test
+```
 
 ## Advanced Configuration
 

--- a/addon-test-support/-private/patch-testem-output.js
+++ b/addon-test-support/-private/patch-testem-output.js
@@ -8,14 +8,18 @@
  * @param {string} testName
  * @return {string} testName
  */
-export function updateTestName(urlParams, testName) {
+ export function updateTestName(urlParams, testName) {
   const split = urlParams.get('split');
   const loadBalance = urlParams.get('loadBalance');
 
   const partition = urlParams.get('partition') || 1;
   const browser = urlParams.get('browser') || 1;
 
-  if (split && loadBalance) {
+  const preserveTestName = !!urlParams.get('preserveTestName');
+
+  if (preserveTestName) {
+    return testName;
+  } else if (split && loadBalance) {
     testName = `Exam Partition ${partition} - Browser Id ${browser} - ${testName}`;
   } else if (split) {
     testName = `Exam Partition ${partition} - ${testName}`;

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -44,6 +44,14 @@ module.exports = TestCommand.extend({
         'Load balance test modules. Test modules will be sorted by weight from slowest (acceptance) to fastest (eslint).',
     },
     {
+      name: 'preserve-test-name',
+      type: Boolean,
+      default: false,
+      aliases: ['ptn'],
+      description:
+        'Preserve the test name when using load balance or split by omitting the partition and browser numbers.',
+    },
+    {
       name: 'random',
       type: String,
       default: false,
@@ -180,6 +188,14 @@ module.exports = TestCommand.extend({
         commandOptions.query,
         'modulePath',
         commandOptions.modulePath
+      );
+    }
+
+    if (commandOptions.preserveTestName) {
+      commandOptions.query = addToQuery(
+        commandOptions.query,
+        'preserveTestName',
+        commandOptions.preserveTestName
       );
     }
 

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -81,6 +81,12 @@ describe('ExamCommand', function () {
       });
     });
 
+    it('should set `preserve-test-name` in the query option', function () {
+      return command.run({ preserveTestName: true }).then(function () {
+        assert.strictEqual(called.testRunOptions.query, 'preserveTestName');
+      });
+    });
+
     it('should set `partition` in the query option with multiple partitions', function () {
       return command.run({ split: 2, partition: [1, 2] }).then(function () {
         assert.strictEqual(

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -15,6 +15,7 @@ Router.map(function () {
     this.route('split-parallel');
     this.route('filtering');
     this.route('load-balancing');
+    this.route('preserve-test-name');
 
     this.route('ember-try-and-ci');
     this.route('test-suite-segmentation');

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -13,6 +13,7 @@
     {{nav.item "Split Test Parallelization" "docs.split-parallel"}}
     {{nav.item "Filtering" "docs.filtering"}}
     {{nav.item "Test Load Balancing" "docs.load-balancing"}}
+    {{nav.item "Preserve Test Name" "docs.preserve-test-name"}}
 
     {{nav.section "Advanced Configuration"}}
     {{nav.item "Ember Try & CI Integration" "docs.ember-try-and-ci"}}

--- a/tests/dummy/app/templates/docs/preserve-test-name.md
+++ b/tests/dummy/app/templates/docs/preserve-test-name.md
@@ -1,0 +1,26 @@
+# Preserve Test Name
+
+When using `--split` and/or `--load-balance` the output will look something like:
+
+```bash
+# ember exam --split=2 --partition=1 --parallel=3 --load-balance
+ok 1 Chrome 66.0 - Exam Partition 1 - browser Id 1 - some test
+ok 2 Chrome 66.0 - Exam Partition 1 - browser Id 2 - another test
+ok 3 Chrome 66.0 - Exam Partition 1 - browser Id 3 - some the other test
+```
+However, if you change the amount of parallelization, or randomize accross partitions, the output will change for the same test, which may be an issue if you are tracking test insights over time. 
+
+```bash
+# ember exam --split=2 --partition=1 --parallel=2 --load-balance
+ok 1 Chrome 66.0 - Exam Partition 1 - browser Id 2 - some test
+ok 2 Chrome 66.0 - Exam Partition 1 - browser Id 1 - another test
+ok 3 Chrome 66.0 - Exam Partition 1 - browser Id 2 - some the other test
+```
+You can add `--preserve-test-name` to remove the dynamic segments of the output (partition and browser) to ensure the output test names are always the same.
+
+```bash
+# ember exam --split=2 --partition=1 --parallel=3 --load-balance --preserve-test-name
+ok 1 Chrome 66.0 - some test
+ok 2 Chrome 66.0 - another test
+ok 3 Chrome 66.0 - some the other test
+```

--- a/tests/unit/mocha/testem-output-test.js
+++ b/tests/unit/mocha/testem-output-test.js
@@ -10,44 +10,94 @@ if (macroCondition(dependencySatisfies('ember-mocha', '*'))) {
   let { expect } = importSync('chai');
 
   describe('Unit | Mocha | patch-testem-output', () => {
-    it('add partition number to test name when `split` is passed', function () {
-      expect(
-        TestemOutput.updateTestName(
-          new Map().set('split', 2),
-          'test_module | test_name'
-        )
-      ).to.equal('Exam Partition 1 - test_module | test_name');
-    });
+    describe('`preserveTestName` is passed', () => {
+      it('does not add partition number to test name when `split` is passed', function () {
+        expect(
+          TestemOutput.updateTestName(
+            new Map().set('split', 2).set('preserveTestName', true),
+            'test_module | test_name'
+          )
+        ).to.equal('test_module | test_name');
+      });
 
-    it('add partition number to test name when `split` and `partition` are passed', function () {
-      expect(
-        TestemOutput.updateTestName(
-          new Map().set('split', 2).set('partition', 2),
-          'test_module | test_name'
-        )
-      ).to.equal('Exam Partition 2 - test_module | test_name');
-    });
+      it('does not add partition number to test name when `split` and `partition` are passed', function () {
+        expect(
+          TestemOutput.updateTestName(
+            new Map()
+              .set('split', 2)
+              .set('partition', 2)
+              .set('preserveTestName', true),
+            'test_module | test_name'
+          )
+        ).to.equal('test_module | test_name');
+      });
 
-    it('add browser number to test name when `loadBalance` and `browser` are passed', function () {
-      expect(
-        TestemOutput.updateTestName(
-          new Map().set('loadBalance', 2).set('browser', 1),
-          'test_module | test_name'
-        )
-      ).to.equal('Browser Id 1 - test_module | test_name');
-    });
+      it('does not add browser number to test name when `loadBalance` and `browser` are passed', function () {
+        expect(
+          TestemOutput.updateTestName(
+            new Map()
+              .set('loadBalance', 2)
+              .set('browser', 1)
+              .set('preserveTestName', true),
+            'test_module | test_name'
+          )
+        ).to.equal('test_module | test_name');
+      });
 
-    it('add partition number, browser number to test name when `split`, `partition`, `browser`, and `loadBalance` are  passed', function () {
-      expect(
-        TestemOutput.updateTestName(
-          new Map()
-            .set('split', 2)
-            .set('partition', 2)
-            .set('browser', 1)
-            .set('loadBalance', 2),
-          'test_module | test_name'
-        )
-      ).to.equal('Exam Partition 2 - Browser Id 1 - test_module | test_name');
+      it('does not add partition number, browser number to test name when `split`, `partition`, `browser`, and `loadBalance` are  passed', function () {
+        expect(
+          TestemOutput.updateTestName(
+            new Map()
+              .set('split', 2)
+              .set('partition', 2)
+              .set('browser', 1)
+              .set('loadBalance', 2)
+              .set('preserveTestName', true),
+            'test_module | test_name'
+          )
+        ).to.equal('test_module | test_name');
+      });
+    });
+    describe('`preserveTestName` is not passed', () => {
+      it('add partition number to test name when `split` is passed', function () {
+        expect(
+          TestemOutput.updateTestName(
+            new Map().set('split', 2),
+            'test_module | test_name'
+          )
+        ).to.equal('Exam Partition 1 - test_module | test_name');
+      });
+
+      it('add partition number to test name when `split` and `partition` are passed', function () {
+        expect(
+          TestemOutput.updateTestName(
+            new Map().set('split', 2).set('partition', 2),
+            'test_module | test_name'
+          )
+        ).to.equal('Exam Partition 2 - test_module | test_name');
+      });
+
+      it('add browser number to test name when `loadBalance` and `browser` are passed', function () {
+        expect(
+          TestemOutput.updateTestName(
+            new Map().set('loadBalance', 2).set('browser', 1),
+            'test_module | test_name'
+          )
+        ).to.equal('Browser Id 1 - test_module | test_name');
+      });
+
+      it('add partition number, browser number to test name when `split`, `partition`, `browser`, and `loadBalance` are  passed', function () {
+        expect(
+          TestemOutput.updateTestName(
+            new Map()
+              .set('split', 2)
+              .set('partition', 2)
+              .set('browser', 1)
+              .set('loadBalance', 2),
+            'test_module | test_name'
+          )
+        ).to.equal('Exam Partition 2 - Browser Id 1 - test_module | test_name');
+      });
     });
   });
 }

--- a/tests/unit/qunit/testem-output-test.js
+++ b/tests/unit/qunit/testem-output-test.js
@@ -9,48 +9,102 @@ if (macroCondition(dependencySatisfies('ember-qunit', '*'))) {
   let { module, test } = importSync('qunit').default;
 
   module('Unit | Qunit | patch-testem-output', () => {
-    test('add partition number to test name when `split` is passed', function (assert) {
-      assert.deepEqual(
-        TestemOutput.updateTestName(
-          new Map().set('split', 2),
+    module('`preserveTestName` is passed', () => {
+      test('does not add partition number to test name when `split` is passed', function (assert) {
+        assert.deepEqual(
+          TestemOutput.updateTestName(
+            new Map().set('split', 2).set('preserveTestName', true),
+            'test_module | test_name'
+          ),
           'test_module | test_name'
-        ),
-        'Exam Partition 1 - test_module | test_name'
-      );
-    });
+        );
+      });
 
-    test('add partition number to test name when `split` and `partition` are passed', function (assert) {
-      assert.deepEqual(
-        TestemOutput.updateTestName(
-          new Map().set('split', 2).set('partition', 2),
+      test('does not add partition number to test name when `split` and `partition` are passed', function (assert) {
+        assert.deepEqual(
+          TestemOutput.updateTestName(
+            new Map()
+              .set('split', 2)
+              .set('partition', 2)
+              .set('preserveTestName', true),
+            'test_module | test_name'
+          ),
           'test_module | test_name'
-        ),
-        'Exam Partition 2 - test_module | test_name'
-      );
-    });
+        );
+      });
 
-    test('add browser number to test name when `loadBalance` and `browser` are passed', function (assert) {
-      assert.deepEqual(
-        TestemOutput.updateTestName(
-          new Map().set('loadBalance', 2).set('browser', 1),
+      test('does not add browser number to test name when `loadBalance` and `browser` are passed', function (assert) {
+        assert.deepEqual(
+          TestemOutput.updateTestName(
+            new Map()
+              .set('loadBalance', 2)
+              .set('browser', 1)
+              .set('preserveTestName', true),
+            'test_module | test_name'
+          ),
           'test_module | test_name'
-        ),
-        'Browser Id 1 - test_module | test_name'
-      );
-    });
+        );
+      });
 
-    test('add partition number, browser number to test name when `split`, `partition`, `browser`, and `loadBalance` are  passed', function (assert) {
-      assert.deepEqual(
-        TestemOutput.updateTestName(
-          new Map()
-            .set('split', 2)
-            .set('partition', 2)
-            .set('browser', 1)
-            .set('loadBalance', 2),
+      test('does not add partition number, browser number to test name when `split`, `partition`, `browser`, and `loadBalance` are  passed', function (assert) {
+        assert.deepEqual(
+          TestemOutput.updateTestName(
+            new Map()
+              .set('split', 2)
+              .set('partition', 2)
+              .set('browser', 1)
+              .set('loadBalance', 2)
+              .set('preserveTestName', true),
+            'test_module | test_name'
+          ),
           'test_module | test_name'
-        ),
-        'Exam Partition 2 - Browser Id 1 - test_module | test_name'
-      );
+        );
+      });
+    });
+    module('`preserveTestName` is not passed', () => {
+      test('add partition number to test name when `split` is passed', function (assert) {
+        assert.deepEqual(
+          TestemOutput.updateTestName(
+            new Map().set('split', 2),
+            'test_module | test_name'
+          ),
+          'Exam Partition 1 - test_module | test_name'
+        );
+      });
+
+      test('add partition number to test name when `split` and `partition` are passed', function (assert) {
+        assert.deepEqual(
+          TestemOutput.updateTestName(
+            new Map().set('split', 2).set('partition', 2),
+            'test_module | test_name'
+          ),
+          'Exam Partition 2 - test_module | test_name'
+        );
+      });
+
+      test('add browser number to test name when `loadBalance` and `browser` are passed', function (assert) {
+        assert.deepEqual(
+          TestemOutput.updateTestName(
+            new Map().set('loadBalance', 2).set('browser', 1),
+            'test_module | test_name'
+          ),
+          'Browser Id 1 - test_module | test_name'
+        );
+      });
+
+      test('add partition number, browser number to test name when `split`, `partition`, `browser`, and `loadBalance` are  passed', function (assert) {
+        assert.deepEqual(
+          TestemOutput.updateTestName(
+            new Map()
+              .set('split', 2)
+              .set('partition', 2)
+              .set('browser', 1)
+              .set('loadBalance', 2),
+            'test_module | test_name'
+          ),
+          'Exam Partition 2 - Browser Id 1 - test_module | test_name'
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
I came across the same issue as https://github.com/ember-cli/ember-exam/issues/129 . Specifically, when I increased our parallelization and added `--random` we lost CI insights as the output changes. To increase consistency in the output I have added an optional flag `--preserve-test-name` that removes the dynamic segments from the output. This is a first attempt at solving the issue, so perhaps it isn't the best way. 
 
Because this is is my first time contributing, I am not sure if I am missing something important here. I would love feedback. Thanks in advance!