### PR TITLE
Check module queue existence when logging

### DIFF
--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -309,23 +309,23 @@ module.exports = TestCommand.extend({
       const launcherId = this.launcher.id;
       if (!failed && commands.get('loadBalance')) {
         const browserId = getBrowserId(this.launcher);
-        log.info(
-          `Browser ${browserId} exiting. [ # of modules in current module queue ${
-            testemEvents.stateManager.getTestModuleQueue().length
-          } ]`
-        );
+        const moduleQueue = testemEvents.stateManager.getTestModuleQueue();
+        const noModuleQueue = 'testModuleQueue is not set.';
+        const numQueues =
+          moduleQueue !== null
+            ? `[ # of modules in current module queue ${moduleQueue.length} ]`
+            : `[ ${noModuleQueue} ]`;
+        log.info(`Browser ${browserId} exiting. ${numQueues}`);
         // if getBrowserId cannot get the browserId
         // but the test queue is not empty, report the number of test modules left in the queue
         // otherwise, fail because testModuleQueue was not set
         if (browserId === 0) {
-          if (testemEvents.stateManager.getTestModuleQueue() !== null) {
+          if (moduleQueue !== null) {
             ui.writeLine(
-              `[ # of modules in current module queue ${
-                testemEvents.stateManager.getTestModuleQueue().length
-              } ]`
+              `[ # of modules in current module queue ${moduleQueue.length} ]`
             );
           } else {
-            throw new Error('testModuleQueue is not set.');
+            throw new Error(noModuleQueue);
           }
         }
       }


### PR DESCRIPTION
The current code makes a null check for the module queue before reading its length, but before it does that, it tries to access the length in another line of code. We should consistently make null checks in both places if we expect it's possible the queue could be null. This issue was masked in v6 and earlier, because the first access of `length` was inside a try-catch block. Upgrading to v7/v8 would causes some test suites to fail out when the module queue comes back as null. While this may indicate an issue, it's clear that the intent of the existing null check was to allow ember-exam to keep operating and not throw if the queue is null. It wouldn't make sense to instead throw for a line of code that's only used for the sake of logging, if we're protecting other parts of the code.