### PR TITLE
Add .codeclimate.yml to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 /tmp/
 
 # misc
+/.codeclimate.yml
 /.editorconfig
 /.ember-cli
 /.env*


### PR DESCRIPTION
File `.codeclimate.yml` does not need to be published to npm, but it does per https://www.npmjs.com/package/ember-exam?activeTab=code