### PR TITLE
Update setup example for new qunit requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ To get the unique features of Ember Exam (described in-depth below), you will ne
 
 ```js
 // test-helper.js
-import { start } from 'ember-exam/test-support';
+- import { start, setupEmberOnerrorValidation } from 'ember-qunit';
++ import { setupEmberOnerrorValidation } from 'ember-qunit';
++ import { start } from 'ember-exam/test-support';
 
 // Options passed to `start` will be passed-through to ember-qunit
 start();


### PR DESCRIPTION
`setupEmberOnerrorValidation` was added to the Vite setup instructions in #1313 but missed for the normal setup guide. This is required as of ember-qunit v9, I believe.