### PR TITLE
Resolve ember-cli version from its installed package.json (fixes crash with pnpm catalogs)

### DIFF
--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -10,6 +10,7 @@ const {
 } = require('../utils/test-page-helper');
 const TestemEvents = require('../utils/testem-events');
 const TestCommand = require('ember-cli/lib/commands/test');
+const { version: emberCliVersion } = require('ember-cli/package.json');
 const TestServerTask = require('./task/test-server');
 const TestTask = require('./task/test');
 
@@ -109,9 +110,7 @@ module.exports = TestCommand.extend({
     this.tasks.Test = TestTask;
     this.tasks.TestServer = TestServerTask;
     this.testemEvents = new TestemEvents(this.project.root);
-    this.emberCliVersion =
-      this.project.pkg.devDependencies['ember-cli'] ||
-      this.project.pkg.dependencies['ember-cli'];
+    this.emberCliVersion = emberCliVersion;
   },
 
   /**

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const semver = require('semver');
 const MockProject = require('ember-cli/tests/helpers/mock-project');
 const Task = require('ember-cli/lib/models/task');
 const RSVP = require('rsvp');
@@ -34,6 +35,22 @@ describe('ExamCommand', function () {
       },
     });
   }
+
+  describe('emberCliVersion', function () {
+    it('uses the resolved ember-cli version, not the declared dependency range', function () {
+      const command = createCommand();
+      command.project.pkg.devDependencies['ember-cli'] =
+        'catalog:ember-ecosystem';
+      command.init();
+
+      const resolved = require('ember-cli/package.json').version;
+      assert.strictEqual(command.emberCliVersion, resolved);
+      assert.ok(
+        semver.validRange(command.emberCliVersion),
+        `expected a valid semver range, got ${command.emberCliVersion}`,
+      );
+    });
+  });
 
   describe('run', function () {
     let command;

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -38,11 +38,28 @@ describe('ExamCommand', function () {
 
   describe('emberCliVersion', function () {
     it('uses the resolved ember-cli version, not the declared dependency range', function () {
-      const command = createCommand();
-      command.project.pkg.devDependencies['ember-cli'] =
-        'catalog:ember-ecosystem';
-      command.init();
+      const tasks = {
+        Build: Task.extend(),
+        Test: Task.extend(),
+      };
 
+      const project = new MockProject();
+      project.isEmberCLIProject = function () {
+        return true;
+      };
+      project.pkg = {
+        devDependencies: {
+          'ember-cli': 'catalog:ember-ecosystem',
+        },
+      };
+
+      const command = new ExamCommand({
+        project: project,
+        tasks: tasks,
+        ui: {
+          writeLine: function () {},
+        },
+      });
       const resolved = require('ember-cli/package.json').version;
       assert.strictEqual(command.emberCliVersion, resolved);
       assert.ok(


### PR DESCRIPTION
> [!NOTE]
> made with claude, and reviewed by me. apologies in advance if I got any of the project's conventions wrong -- happy to adjust.

`ember exam --load-balance` crashes in any repo using [pnpm catalogs](https://pnpm.io/catalogs), with a cryptic:

```
TypeError: Cannot read properties of null (reading 'trim')
    at new Range (semver/classes/range.js)
    at outside (semver/ranges/outside.js)
    at Object.gtr (semver/ranges/gtr.js)
```

we read the ember-cli version out of the app's declared dependency range:

```js
this.emberCliVersion =
  this.project.pkg.devDependencies['ember-cli'] ||
  this.project.pkg.dependencies['ember-cli'];
```

but with catalogs (and `workspace:`) that's left verbatim as `"catalog:ember-ecosystem"` on disk -- pnpm only resolves the alias in the lockfile. so `semver.validRange(...)` returns `null`, and `validateLoadBalance`'s `semver.gtr('3.2.0', null)` blows up on `new Range(null)`.

fix: read the version from ember-cli's own (installed, always-resolved) `package.json` instead. bonus: it's the version actually in use, not just what's declared.

added a regression test. `pnpm test:node` green, lint clean.
