### PR TITLE
Update test name on tests-start, guard updateTestName against double-prefixing

### DIFF
--- a/addon-test-support/-private/patch-testem-output.js
+++ b/addon-test-support/-private/patch-testem-output.js
@@ -9,6 +9,11 @@
  * @return {string} testName
  */
 export function updateTestName(urlParams, testName) {
+  if (testName.includes('Exam Partition') || testName.includes('Browser Id')) {
+    // The test name was already updated, e.g. by the `tests-start` event
+    return testName;
+  }
+
   const split = urlParams.get('split');
   const loadBalance = urlParams.get('loadBalance');
 
@@ -31,12 +36,18 @@ export function updateTestName(urlParams, testName) {
 }
 
 /**
- * Setup testem test-result event to update the test name when a test completes
+ * Setup testem tests-start and test-result events to update the test name
+ * when a test starts and when it completes
  *
  * @function patchTestemOutput
  * @param {Map} urlParams
  */
 export function patchTestemOutput(urlParams) {
+  Testem.on('tests-start', (test) => {
+    if (test?.name) {
+      test.name = updateTestName(urlParams, test.name);
+    }
+  });
   Testem.on('test-result', (test) => {
     test.name = updateTestName(urlParams, test.name);
   });

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -12,7 +12,7 @@ function assertExpectRejection() {
   assert.ok(false, 'Expected promise to reject, but it fullfilled');
 }
 
-const TOTAL_NUM_TESTS = 67; // Total Number of tests without the global 'Ember.onerror validation tests'
+const TOTAL_NUM_TESTS = 71; // Total Number of tests without the global 'Ember.onerror validation tests'
 
 function getTotalNumberOfTests(output) {
   // In ember-qunit 3.4.0, this new check was added: https://github.com/emberjs/ember-qunit/commit/a7e93c4b4b535dae62fed992b46c00b62bfc83f4

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -607,7 +607,7 @@ describe('Acceptance | Exam Command', function () {
         assertOutput(output, 'Browser Id', ['2']);
         assert.strictEqual(
           getNumberOfTests(output),
-          44,
+          48,
           'ran all of the tests for browser two',
         );
       });

--- a/tests/unit/testem-output-test.js
+++ b/tests/unit/testem-output-test.js
@@ -99,5 +99,63 @@ module('Unit | patch-testem-output', function () {
         'Exam Partition 2 - Browser Id 1 - test_module | test_name',
       );
     });
+
+    test('does not add partition number again when the test name already contains it', function (assert) {
+      assert.deepEqual(
+        TestemOutput.updateTestName(
+          new Map().set('split', 2).set('partition', 2),
+          'Exam Partition 2 - test_module | test_name',
+        ),
+        'Exam Partition 2 - test_module | test_name',
+      );
+    });
+
+    test('does not add browser number again when the test name already contains it', function (assert) {
+      assert.deepEqual(
+        TestemOutput.updateTestName(
+          new Map().set('loadBalance', 2).set('browser', 1),
+          'Browser Id 1 - test_module | test_name',
+        ),
+        'Browser Id 1 - test_module | test_name',
+      );
+    });
+  });
+
+  module('patchTestemOutput', function (hooks) {
+    let originalTestem;
+    let handlers;
+
+    hooks.beforeEach(function () {
+      originalTestem = window.Testem;
+      handlers = new Map();
+      window.Testem = {
+        on(event, callback) {
+          handlers.set(event, callback);
+        },
+      };
+    });
+
+    hooks.afterEach(function () {
+      window.Testem = originalTestem;
+    });
+
+    test('updates the test name when a test starts and when it completes', function (assert) {
+      TestemOutput.patchTestemOutput(new Map().set('split', 2));
+
+      const test = { name: 'test_module | test_name' };
+      handlers.get('tests-start')(test);
+      assert.deepEqual(test.name, 'Exam Partition 1 - test_module | test_name');
+
+      handlers.get('test-result')(test);
+      assert.deepEqual(test.name, 'Exam Partition 1 - test_module | test_name');
+    });
+
+    test('handles tests-start events without a test name', function (assert) {
+      TestemOutput.patchTestemOutput(new Map().set('split', 2));
+
+      const test = {};
+      handlers.get('tests-start')(test);
+      assert.deepEqual(test.name, undefined);
+    });
   });
 });


### PR DESCRIPTION
> [!IMPORTANT]
> made with claude

I'm not an expert in this codebase, and could be way off base, and I apologize if this is a waste of time / completely wrong

-------------------------

At AuditBoard we've been carrying this as a local patch to ember-exam for a while and it seems worth upstreaming.

## Problem

`patchTestemOutput` only renames tests on the `test-result` event. Anything consuming testem's live progress reporting (the `tests-start` event) sees the unprefixed name, so a currently-running test can't be attributed to its partition/browser — which matters when tracking down which browser a hung or slow test belongs to.

## Changes

- `patchTestemOutput` now also subscribes to `tests-start` and applies the same rename (guarded with `test?.name`, since not every `tests-start` payload has a name).
- `updateTestName` returns early if the name already contains the `Exam Partition` / `Browser Id` prefix, so renaming on both events doesn't stack prefixes onto the same test object.

## Testing

Added unit tests to `tests/unit/testem-output-test.js`:

- `updateTestName` is idempotent for already-prefixed names (partition and browser variants)
- `patchTestemOutput` (with a stubbed `Testem` global) renames on `tests-start`, doesn't double-prefix on the subsequent `test-result`, and tolerates a `tests-start` payload without a name

All 12 tests in the module pass locally via `ember test --filter="patch-testem-output"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)