### PR TITLE
Fix CI for ember-release/beta/canary (Ember 7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,9 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          # ember-cli >= 6.10 (needed by the ember-release/beta/canary
+          # scenarios for Ember 7) requires node >= 20.19
+          node-version: 22
           cache: 'pnpm'
       - run: pnpm install
       - run: node_modules/.bin/ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chalk": "^5.3.0",
     "cli-table3": "^0.6.0",
     "debug": "^4.2.0",
-    "ember-auto-import": "^2.7.0",
+    "ember-auto-import": "^2.13.1",
     "ember-cli-babel": "^8.2.0",
     "execa": "^8.0.1",
     "fs-extra": "^11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^4.2.0
         version: 4.4.1
       ember-auto-import:
-        specifier: ^2.7.0
-        version: 2.10.0(webpack@5.104.1)
+        specifier: ^2.13.1
+        version: 2.13.1(webpack@5.104.1)
       ember-cli-babel:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.28.3)
@@ -1556,10 +1556,6 @@ packages:
 
   '@embroider/reverse-exports@0.2.0':
     resolution: {integrity: sha512-WFsw8nQpHZiWGEDYpa/A79KEFfTisqteXbY+jg9eZiww1r1G+LZvsmdszDp86TkotUSCqrMbK/ewn0jR1CJmqg==}
-    engines: {node: 12.* || 14.* || >= 16}
-
-  '@embroider/shared-internals@2.9.1':
-    resolution: {integrity: sha512-8PJBsa37GD++SAfHf8rcJzlwDwuAQCBo0fr+eGxg9l8XhBXsTnE/7706dM4OqWew9XNqRXn39wfIGHZoBpjNMw==}
     engines: {node: 12.* || 14.* || >= 16}
 
   '@embroider/shared-internals@2.9.2':
@@ -4376,12 +4372,12 @@ packages:
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
-  ember-auto-import@2.10.0:
-    resolution: {integrity: sha512-bcBFDYVTFHyqyq8BNvsj6UO3pE6Uqou/cNmee0WaqBgZ+1nQqFz0UE26usrtnFAT+YaFZSkqF2H36QW84k0/cg==}
-    engines: {node: 12.* || 14.* || >= 16}
-
   ember-auto-import@2.12.1:
     resolution: {integrity: sha512-wyvl+aJJKOKbRSLqq6CyMsNrvurmX4SIWHHqZdC5giZ7P8ECGmcn9W9HFoVLpwXkFJoXhNV4L7mqqcU6881t0w==}
+    engines: {node: 12.* || 14.* || >= 16}
+
+  ember-auto-import@2.13.1:
+    resolution: {integrity: sha512-MjxJK2nfCJmmQI/rju2TrycmAa1AxmTarfvygbcrrgW0s4WeZHtbGXCO2z1lW9wfrShqeTo/o+3Mgk+9xcDTWg==}
     engines: {node: 12.* || 14.* || >= 16}
 
   ember-cli-app-version@7.0.0:
@@ -12025,7 +12021,7 @@ snapshots:
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       dom-element-descriptors: 0.5.1
-      ember-auto-import: 2.10.0(webpack@5.104.1)
+      ember-auto-import: 2.13.1(webpack@5.104.1)
       ember-cli-babel: 8.2.0(@babel/core@7.29.7)
       ember-cli-htmlbars: 6.3.0
       ember-source: 5.12.0(7db106b9f5d10f834208945439abe83e)
@@ -12043,7 +12039,7 @@ snapshots:
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       dom-element-descriptors: 0.5.1
-      ember-auto-import: 2.10.0(webpack@5.104.1)
+      ember-auto-import: 2.13.1(webpack@5.104.1)
       ember-cli-babel: 8.2.0(@babel/core@7.28.3)
       ember-cli-htmlbars: 6.3.0
       ember-source: 6.10.1(rsvp@4.8.5)
@@ -12361,23 +12357,6 @@ snapshots:
     dependencies:
       mem: 8.1.1
       resolve.exports: 2.0.3
-
-  '@embroider/shared-internals@2.9.1':
-    dependencies:
-      babel-import-util: 2.1.1
-      debug: 4.4.1
-      ember-rfc176-data: 0.3.18
-      fs-extra: 9.1.0
-      is-subdir: 1.2.0
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      minimatch: 3.1.5
-      pkg-entry-points: 1.1.1
-      resolve-package-path: 4.0.3
-      semver: 7.7.2
-      typescript-memoize: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@embroider/shared-internals@2.9.2':
     dependencies:
@@ -14281,15 +14260,6 @@ snapshots:
 
   babel-import-util@3.0.1: {}
 
-  babel-loader@8.4.1(@babel/core@7.28.3)(webpack@5.104.1):
-    dependencies:
-      '@babel/core': 7.28.3
-      find-cache-dir: 3.3.2
-      loader-utils: 2.0.4
-      make-dir: 3.1.0
-      schema-utils: 2.7.1
-      webpack: 5.104.1
-
   babel-loader@8.4.1(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
@@ -15776,49 +15746,6 @@ snapshots:
 
   electron-to-chromium@1.5.267: {}
 
-  ember-auto-import@2.10.0(webpack@5.104.1):
-    dependencies:
-      '@babel/core': 7.28.3
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.28.3)
-      '@babel/plugin-proposal-decorators': 7.28.6(@babel/core@7.28.3)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.28.3)
-      '@babel/plugin-transform-class-static-block': 7.27.1(@babel/core@7.28.3)
-      '@babel/preset-env': 7.28.0(@babel/core@7.28.3)
-      '@embroider/macros': 1.18.1
-      '@embroider/shared-internals': 2.9.1
-      babel-loader: 8.4.1(@babel/core@7.28.3)(webpack@5.104.1)
-      babel-plugin-ember-modules-api-polyfill: 3.5.0
-      babel-plugin-ember-template-compilation: 2.4.1
-      babel-plugin-htmlbars-inline-precompile: 5.3.1
-      babel-plugin-syntax-dynamic-import: 6.18.0
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
-      broccoli-plugin: 4.0.7
-      broccoli-source: 3.0.1
-      css-loader: 5.2.7(webpack@5.104.1)
-      debug: 4.4.1
-      fs-extra: 10.1.0
-      fs-tree-diff: 2.0.1
-      handlebars: 4.7.8
-      is-subdir: 1.2.0
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.104.1)
-      minimatch: 3.1.2
-      parse5: 6.0.1
-      pkg-entry-points: 1.1.1
-      resolve: 1.22.10
-      resolve-package-path: 4.0.3
-      semver: 7.7.2
-      style-loader: 2.0.0(webpack@5.104.1)
-      typescript-memoize: 1.1.1
-      walk-sync: 3.0.0
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-      - webpack
-
   ember-auto-import@2.12.1:
     dependencies:
       '@babel/core': 7.29.7
@@ -15894,6 +15821,94 @@ snapshots:
       lodash: 4.17.21
       mini-css-extract-plugin: 2.9.2(webpack@5.104.1)
       minimatch: 3.1.2
+      parse5: 6.0.1
+      pkg-entry-points: 1.1.1
+      resolve: 1.22.10
+      resolve-package-path: 4.0.3
+      semver: 7.7.2
+      style-loader: 2.0.0(webpack@5.104.1)
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+
+  ember-auto-import@2.13.1:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-decorators': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-static-block': 7.27.1(@babel/core@7.29.7)
+      '@babel/preset-env': 7.28.0(@babel/core@7.29.7)
+      '@embroider/macros': 1.19.7(@babel/core@7.29.7)
+      '@embroider/reverse-exports': 0.2.0
+      '@embroider/shared-internals': 2.9.2
+      babel-loader: 8.4.1(@babel/core@7.29.7)
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-ember-template-compilation: 2.4.1
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      css-loader: 5.2.7
+      debug: 4.4.1
+      fs-extra: 10.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.8
+      is-subdir: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2
+      minimatch: 3.1.5
+      parse5: 6.0.1
+      pkg-entry-points: 1.1.1
+      resolve: 1.22.10
+      resolve-package-path: 4.0.3
+      semver: 7.7.2
+      style-loader: 2.0.0
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+
+  ember-auto-import@2.13.1(webpack@5.104.1):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-decorators': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-static-block': 7.27.1(@babel/core@7.29.7)
+      '@babel/preset-env': 7.28.0(@babel/core@7.29.7)
+      '@embroider/macros': 1.19.7(@babel/core@7.29.7)
+      '@embroider/reverse-exports': 0.2.0
+      '@embroider/shared-internals': 2.9.2
+      babel-loader: 8.4.1(@babel/core@7.29.7)(webpack@5.104.1)
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-ember-template-compilation: 2.4.1
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      css-loader: 5.2.7(webpack@5.104.1)
+      debug: 4.4.1
+      fs-extra: 10.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.8
+      is-subdir: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.2(webpack@5.104.1)
+      minimatch: 3.1.5
       parse5: 6.0.1
       pkg-entry-points: 1.1.1
       resolve: 1.22.10
@@ -16822,7 +16837,7 @@ snapshots:
       chalk: 5.4.1
       cli-table3: 0.6.5
       debug: 4.4.1
-      ember-auto-import: 2.12.1(webpack@5.104.1)
+      ember-auto-import: 2.13.1(webpack@5.104.1)
       ember-cli-babel: 8.2.0(@babel/core@7.29.7)
       ember-qunit: 9.0.4(64f13abf81729d24f00e51be62059cfa)
       ember-source: 6.10.1(@glimmer/component@2.0.0)
@@ -16845,7 +16860,7 @@ snapshots:
       chalk: 5.4.1
       cli-table3: 0.6.5
       debug: 4.4.1
-      ember-auto-import: 2.12.1(webpack@5.104.1)
+      ember-auto-import: 2.13.1(webpack@5.104.1)
       ember-cli-babel: 8.2.0(@babel/core@7.29.7)
       ember-qunit: 8.1.1(a13e2bb03fcb50e01154ec020748c431)
       ember-source: 5.12.0(7db106b9f5d10f834208945439abe83e)
@@ -16868,7 +16883,7 @@ snapshots:
       chalk: 5.4.1
       cli-table3: 0.6.5
       debug: 4.4.1
-      ember-auto-import: 2.12.1
+      ember-auto-import: 2.13.1
       ember-cli-babel: 8.2.0(@babel/core@7.29.7)
       ember-qunit: 9.0.4(64f13abf81729d24f00e51be62059cfa)
       ember-source: 6.10.1(@glimmer/component@2.0.0)
@@ -17031,7 +17046,7 @@ snapshots:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.12.1(webpack@5.104.1)
+      ember-auto-import: 2.13.1(webpack@5.104.1)
       ember-cli-babel: 8.2.0(@babel/core@7.29.7)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -16,6 +16,18 @@ const command = [
   .filter(Boolean)
   .join(' ');
 
+// Ember 7+ publishes ember-source as a v2 addon without AMD/vendor bundles,
+// so the release/beta/canary scenarios need newer build tooling than this
+// repo's defaults. See https://deprecations.emberjs.com/id/using-amd-bundles
+const ember7Tooling = {
+  'ember-cli': '^6.11.1',
+  'ember-cli-htmlbars': '^7.0.1',
+  '@ember/test-helpers': '^5.4.3',
+  'ember-resolver': '^13.2.0',
+  'ember-qunit': '^9.1.0',
+  '@glimmer/component': '^2.0.0',
+};
+
 module.exports = async function () {
   return {
     command,
@@ -42,6 +54,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('release'),
+            ...ember7Tooling,
           },
         },
       },
@@ -50,6 +63,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
+            ...ember7Tooling,
           },
         },
       },
@@ -58,6 +72,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            ...ember7Tooling,
           },
         },
       },


### PR DESCRIPTION
## Problem

The `ember-release`, `ember-beta`, and `ember-canary` try scenarios have been failing since the release channel moved to Ember 7. Ember 7 publishes `ember-source` as a v2 addon and no longer ships the AMD/vendor bundles — see the [using-amd-bundles deprecation guide](https://deprecations.emberjs.com/id/using-amd-bundles) and [RFC 1101](https://rfcs.emberjs.com/id/1101-deprecate-ember-vendor-bundles/). Our pinned tooling chokes on that, failing one layer at a time:

1. `ember-cli@5.12` crashes in `_initVendorFiles` reading `emberSource.paths.debug` (`Cannot read properties of undefined (reading 'debug')`)
2. `ember-cli-htmlbars@6.x` crashes reading the removed `templateCompiler` path
3. `ember-resolver@11` does `import Ember from 'ember'`, which no longer exists

## Fix

- **`tests/dummy/config/ember-try.js`**: the three Ember 7 channel scenarios now override the build tooling to versions that support v2 `ember-source` (`ember-cli@^6.11`, `ember-cli-htmlbars@^7`, `@ember/test-helpers@^5`, `ember-resolver@^13`, `ember-qunit@^9.1`, `@glimmer/component@^2` — now a peer of ember-source). Kept as per-scenario overrides so the LTS scenarios and the base setup stay on their current versions.
- **`package.json`**: bumped the addon's `ember-auto-import` dependency floor `^2.7.0` → `^2.13.1`, the minimum version that provides the ember modules per the deprecation guide. (It has to be the real dependency: a scenario devDependency override can't win over the production dependency resolution.)
- **`.github/workflows/ci.yml`**: the try-scenarios job moves from Node 18 to Node 22, since `ember-cli >= 6.10` requires Node >= 20.19.

## Verification

Ran locally:

| Scenario | Result |
|---|---|
| ember-release (7.1.0-release) | 70/70 pass |
| ember-beta | 70/70 pass |
| ember-canary | 70/70 pass |
| ember-lts-4.8 | 70/70 pass |
| base `pnpm test:ember` (ember-source 6.10.1) | 68/68 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)