### PR TITLE
Don't crash a load-balanced run to print a log line

### DIFF
--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -286,9 +286,10 @@ module.exports = TestCommand.extend({
       const launcherId = this.launcher.id;
       if (!failed && commands.get('loadBalance')) {
         const browserId = getBrowserId(this.launcher);
+        const testModuleQueue = testemEvents.stateManager.getTestModuleQueue();
         log.info(
           `Browser ${browserId} exiting. [ # of modules in current module queue ${
-            testemEvents.stateManager.getTestModuleQueue().length
+            testModuleQueue === null ? 'not set' : testModuleQueue.length
           } ]`,
         );
         // if getBrowserId cannot get the browserId

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -282,6 +282,27 @@ describe('ExamCommand', function () {
       assert.strictEqual(this.events['disconnect'], undefined);
     });
 
+    it('does not throw when a browser exits before the module queue is set', function () {
+      // The queue is null until some browser emits testem:set-modules-queue, and
+      // null again once drained. A browser exiting in either window used to hit
+      // `getTestModuleQueue().length` in the log line and take the run down with
+      // a TypeError, pre-empting the explicit 'testModuleQueue is not set.' error
+      // a few lines below it.
+      this.command.commands.set('loadBalance', true);
+
+      const runner = createRunner(1);
+
+      this.events['tests-start'].call(runner);
+
+      assert.strictEqual(
+        this.command.testemEvents.stateManager.getTestModuleQueue(),
+        null,
+      );
+      assert.doesNotThrow(() => {
+        this.events['after-tests-complete'].call(runner);
+      });
+    });
+
     it('does not reset the module queue when one of two browsers finishes', async function () {
       const runner1 = createRunner(1);
       const runner2 = createRunner(2);


### PR DESCRIPTION
> [!NOTE]
> Made with Claude Code. Apologies if I've misread the intent here — happy to rework or close it.

`browserExitHandler` reads the module queue unconditionally to build a log line:

```js
log.info(
  `Browser ${browserId} exiting. [ # of modules in current module queue ${
    testemEvents.stateManager.getTestModuleQueue().length
  } ]`,
);
```

The queue is `null` until some browser emits `testem:set-modules-queue`, and `null` again once drained. A browser exiting in either window takes the run down:

```
TypeError: Cannot read properties of null (reading 'length')
    at BrowserTestRunner.browserExitHandler (lib/commands/exam.js:291:59)
    at events.after-tests-complete (lib/commands/exam.js:399:33)
```

The next branch in the same function already treats that state as expected:

```js
if (testemEvents.stateManager.getTestModuleQueue() !== null) {
  ui.writeLine(`[ # of modules in current module queue ${…length} ]`);
} else {
  throw new Error('testModuleQueue is not set.');
}
```

So the read above it pre-empts a deliberate, informative error with an opaque one — for a log line. This prints `not set` instead and lets that path run.

## How I hit it

Adding V8 coverage collection to a large app's `--load-balance` suite. The coverage tooling reloads the page to arm coverage before scripts compile, which shifts when browsers connect and exit relative to the queue being populated. Nothing exotic — any timing change that lets a browser exit outside the queue's lifetime does it, and the failure gives you no clue where to look.

## Tests

Added a case to the existing `browser socket events` block. It fails on `main` with the exact production error and passes with the fix:

```
1) does not throw when a browser exits before the module queue is set
   Actual message: "Cannot read properties of null (reading 'length')"
```

The existing tests in that block all run with `loadBalance: false`, so this branch wasn't covered.

`pnpm test:node` on `main`: **159 passing, 5 failing**. With this change: **161 passing, 4 failing** — the fix also repairs the currently-failing `Acceptance | Exam Command`. The remaining four (`Acceptance | Exam Iterate Command` ×3, `Command | exam | vite`) fail identically on a clean `main` and are untouched by this.
