### PR TITLE
chore: trim npm package to exclude test-apps/, docs-app/, and other dev-only files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -23,11 +23,15 @@
 /CHANGELOG.md
 /CONTRIBUTING.md
 /config/
+/docs-app/
 /ember-cli-build.js
 /node-tests/
+/.release-plan.json
 /RELEASE.md
+/test-apps/
 /testem*.js
 /tests/
+/pnpm-workspace.yaml
 /yarn.lock
 /*.tgz
 .gitkeep


### PR DESCRIPTION
## Summary

`.npmignore` excludes the root-level classic dummy-app scaffold (`config/`, `tests/`, `node-tests/`, `ember-cli-build.js`) but was never updated after `test-apps/` (the 3 fixture apps used for the addon's own compat-matrix testing: broccoli, embroider3-webpack, vite-with-compat) and `docs-app/` (the documentation site) were added later. Together these account for 95 of the 124 files currently published to npm — none of which are needed by consumers; only `lib/`, `addon-test-support/`, `index.js`, and `package.json` actually are.

Also excludes `pnpm-workspace.yaml` and `.release-plan.json`, which are internal monorepo/release tooling config with no relevance post-install.

**Before:** 124 files, 182.5 kB unpacked
**After:** 27 files, 106.4 kB unpacked

## Note on scope

I originally also looked at moving `ember-cli-babel`/`ember-auto-import` from `dependencies` to `devDependencies`, since they're unused by `index.js`/`lib/`/`addon-test-support/` at runtime (no addon/app tree, no decorators or other syntax needing transformation). That turns out to be load-bearing, though: classic ember-cli's addon-tree-merging explicitly requires a JS preprocessor listed in `dependencies` (not `devDependencies`) to process `addon-test-support/` for consumers still on a classic/compat-style build — confirmed by `test-apps/vite-with-compat`'s own test failing locally when I tried it (`Addon test-support files were detected ... but no JavaScript preprocessor was found`). So I left those alone; this PR is scoped to the safe packaging cleanup only.

## Test plan
- [x] `npm pack --dry-run` — confirms 124 → 27 files
- [x] `pnpm test:node` — 163 passing / 1 failing, same pre-existing failure (`testem ENOENT`) reproduced identically on unmodified `main`, unrelated to this change
- [x] `pnpm lint` — passing